### PR TITLE
Update Help output

### DIFF
--- a/src/GitHubLink/HelpWriter.cs
+++ b/src/GitHubLink/HelpWriter.cs
@@ -28,10 +28,10 @@ namespace GitHubLink
 
 Note that the solution must be built because this application will update existing pdb files.
 
-GitHubLink [solutionPath] -url [urlToRepository]
+GitHubLink [solutionPath] -u [urlToRepository]
 
     solutionPath       The directory containing the solution with the pdb files.
-    -url [url]         Url to remote git repository.
+    -u [url]           Url to remote git repository.
     -c [config]        Name of the configuration, default value is 'Release'.
     -b [branch]        Name of the branch to use on the remote repository.
     -l [file]          The log file to write to.


### PR DESCRIPTION
Trying to use `-url` throws:

``` sh
Could not parse command line parameter '-url'.
An unexpected error occurred | [GitHubLinkException] GitHubLink.GitHubLinkException: Could not parse command line parame
ter '-url'.
   at Catel.Logging.LogExtensions.ErrorAndThrowException[TException](ILog log, String messageFormat, Object[] args) in c:\CI_WS\Ws\1459\Source\Catel\src\Catel.Core\Catel.Core.NET40\Logging\Extensions\LogExtensions.cs:line 362
   at GitHubLink.ArgumentParser.ParseArguments(List`1 commandLineArguments)
   at GitHubLink.Program.Main(String[] args)
```
