### PR TITLE
Add -d argument to override where to look for pdb files

### DIFF
--- a/src/GitLink.Tests/ArgumentParserFacts.cs
+++ b/src/GitLink.Tests/ArgumentParserFacts.cs
@@ -37,6 +37,15 @@ namespace GitLink.Tests
         }
 
         [TestCase]
+        public void CorrectlyParsesPdbFilesDirectory()
+        {
+            var context = ArgumentParser.ParseArguments("solutionDirectory -d pdbFilesDirectory");
+
+            Assert.AreEqual("solutionDirectory", context.SolutionDirectory);
+            Assert.AreEqual("pdbFilesDirectory", context.PdbFilesDirectory);
+        }
+
+        [TestCase]
         public void CorrectlyParsesHelp()
         {
             var context = ArgumentParser.ParseArguments("-h");

--- a/src/GitLink/ArgumentParser.cs
+++ b/src/GitLink/ArgumentParser.cs
@@ -114,6 +114,12 @@ namespace GitLink
                     continue;
                 }
 
+                if (IsSwitch("d", name))
+                {
+                    context.PdbFilesDirectory = value;
+                    continue;
+                }
+
                 if (IsSwitch("ignore", name))
                 {
                     context.IgnoredProjects.AddRange(value.Split(new []{ ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));

--- a/src/GitLink/Context.cs
+++ b/src/GitLink/Context.cs
@@ -74,6 +74,8 @@ namespace GitLink
 
         public List<string> IgnoredProjects { get; private set; }
 
+        public string PdbFilesDirectory { get; set; }
+
         public void ValidateContext()
         {
             if (!string.IsNullOrWhiteSpace(SolutionDirectory))

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -55,6 +55,17 @@ namespace GitLink
 
             var srcsrvFile = GetOutputSrcSrvFile(project);
 
+            CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile);
+        }
+
+        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile)
+        {
+            Argument.IsNotNull(() => project);
+            Argument.IsNotNullOrWhitespace(() => rawUrl);
+            Argument.IsNotNullOrWhitespace(() => revision);
+            Argument.IsNotNullOrWhitespace(() => srcsrvFile);
+
+
             File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value))));
         }
 
@@ -71,7 +82,12 @@ namespace GitLink
 
             var pdbFile = GetOutputPdbFile(project);
 
-            using (var pdb = new PdbFile(pdbFile))
+            return VerifyPdbFiles(project, files, pdbFile);
+        }
+
+        public static Dictionary<string, string> VerifyPdbFiles(this Project project, IEnumerable<string> files, string pdbFileFullPath)
+        {
+            using(var pdb = new PdbFile(pdbFileFullPath))
             {
                 return pdb.VerifyPdbFiles(files);
             }

--- a/src/GitLink/HelpWriter.cs
+++ b/src/GitLink/HelpWriter.cs
@@ -37,6 +37,8 @@ GitLink [solutionPath] -u [urlToRepository]
     -b [branch]        Name of the branch to use on the remote repository.
     -l [file]          The log file to write to.
     -s [shaHash]       The SHA-1 hash of the commit.
+    -d [pdbDirectory]  The directory where pdb files exists, default value 
+                       is the normal project output directory.
     -debug             Enables debug mode with special dumps of msbuild.
 ";
             writer(message);


### PR DESCRIPTION
This PR adds a new command argument: `-d pdbFilesDirectory` that allows the user to specify where the pdb files are.
This is useful when a solution has been built with `/p:OutDir=c:\SomeDirectory` argument to specify an output directory where dlls and pdbs will end up in..