### PR TITLE
(#37) Add CustomRawUrlProvider to enable arbitrary content URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ When specific projects should be ignored, use the *-ignore* option. This option 
 
 	GitLink.exe c:\source\catel -u https://github.com/catel/catel -f Catel.sln -ignore Catel.Core.WP80,Catel.MVVM.WP80
 
+## Running for a custom raw content URL
+
+When working with a content proxy or an alternative git VCS system that supports direct HTTP access to specific file revisions use the `-u` parameter with the custom raw content root URL
+
+    GitLink.exe c:\source\catel -u https://raw.githubusercontent.com/catel/catel
+    
+The custom url will be used to fill in the following pattern `{customUrl}/{revision}/{raltiveFilePath}` when generating the source mapping.
+
 ## Getting help
 
 When you need help about GitLink, use the following command line:

--- a/src/GitLink.Tests/GitLink.Tests.csproj
+++ b/src/GitLink.Tests/GitLink.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="GlobalInitialization.cs" />
     <Compile Include="Providers\BitBucketProviderFacts.cs" />
+    <Compile Include="Providers\CustomRawUrlProviderFacts.cs" />
     <Compile Include="Providers\GitHubProviderFacts.cs" />
     <Compile Include="Providers\ProviderManagerFacts.cs" />
   </ItemGroup>

--- a/src/GitLink.Tests/Providers/CustomRawUrlProviderFacts.cs
+++ b/src/GitLink.Tests/Providers/CustomRawUrlProviderFacts.cs
@@ -1,0 +1,82 @@
+﻿namespace GitLink.Tests.Providers
+{
+    using GitLink.Providers;
+    using NUnit.Framework;
+
+    public class CustomRawUrlProviderFacts
+    {
+        [TestFixture]
+        public class TheInitialization
+        {
+            [TestCase("http://example.com/repo", true)]
+            [TestCase("https://example.com/repo", true)]
+            [TestCase("https://example.com/repo/", true)]
+            [TestCase("gopher://example.com/repo", false)]
+            public void CorrectlyValidatesForUrls(string url, bool expectedValue)
+            {
+                var provider = new CustomRawUrlProvider();
+                var valid = provider.Initialize(url);
+
+                Assert.AreEqual(expectedValue, valid);
+            }
+        }
+
+        [TestFixture]
+        public class TheGitHubProviderProperties
+        {
+            [TestCase]
+            public void ReturnsNullCompany()
+            {
+                var provider = new CustomRawUrlProvider();
+                provider.Initialize("http://example.com/repo");
+
+                Assert.IsNull(provider.CompanyName);
+            }
+
+            [TestCase]
+            public void ReturnsNullCompanyUrl()
+            {
+                var provider = new CustomRawUrlProvider();
+                provider.Initialize("http://example.com/repo");
+
+                Assert.IsNull(provider.CompanyUrl);
+            }
+
+            [TestCase]
+            public void ReturnsNullProject()
+            {
+                var provider = new CustomRawUrlProvider();
+                provider.Initialize("http://example.com/repo");
+
+                Assert.IsNull(provider.ProjectName);
+            }
+
+            [TestCase]
+            public void ReturnsNullProjectUrl()
+            {
+                var provider = new CustomRawUrlProvider();
+                provider.Initialize("http://example.com/repo");
+
+                Assert.IsNull(provider.ProjectUrl);
+            }
+
+            [TestCase]
+            public void ReturnsValidRawGitUrl()
+            {
+                var provider = new CustomRawUrlProvider();
+                provider.Initialize("http://example.com/repo");
+
+                Assert.AreEqual("http://example.com/repo", provider.RawGitUrl);
+            }
+
+            [TestCase]
+            public void ReturnsValidRawGitUrlWithNoTrailingSlash()
+            {
+                var provider = new CustomRawUrlProvider();
+                provider.Initialize("http://example.com/repo/");
+
+                Assert.AreEqual("http://example.com/repo", provider.RawGitUrl);
+            }
+        }
+    }
+}

--- a/src/GitLink.Tests/Providers/ProviderManagerFacts.cs
+++ b/src/GitLink.Tests/Providers/ProviderManagerFacts.cs
@@ -18,6 +18,7 @@ namespace GitLink.Tests.Providers
         {
             [TestCase("https://bitbucket.org/CatenaLogic/GitLink", typeof(BitBucketProvider))]
             [TestCase("https://github.com/CatenaLogic/GitLink", typeof(GitHubProvider))]
+            [TestCase("https://example.com/repo", typeof(CustomRawUrlProvider))]
             [TestCase("", null)]
             public void ReturnsRightProvider(string url, Type expectedType)
             {

--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Context.cs" />
     <Compile Include="Providers\BitBucketProvider.cs" />
+    <Compile Include="Providers\CustomRawUrlProvider.cs" />
     <Compile Include="Providers\GitHubProvider.cs" />
     <Compile Include="Providers\Interfaces\IProviderManager.cs" />
     <Compile Include="Providers\Interfaces\IProvider.cs" />

--- a/src/GitLink/Providers/CustomRawUrlProvider.cs
+++ b/src/GitLink/Providers/CustomRawUrlProvider.cs
@@ -1,0 +1,42 @@
+﻿namespace GitLink.Providers
+{
+    using System;
+    using System.Text.RegularExpressions;
+    using GitTools.Git;
+
+    public sealed class CustomRawUrlProvider : ProviderBase
+    {
+        private readonly Regex _regex = new Regex(@"https?://.+");
+
+        private string _rawUrl;
+
+        public CustomRawUrlProvider()
+            : base(new GitPreparer())
+        {
+        }
+
+        public override string RawGitUrl
+        {
+            get
+            {
+                return _rawUrl;
+            }
+        }
+
+        public override bool Initialize(string url)
+        {
+            if (string.IsNullOrEmpty(url) || !_regex.IsMatch(url))
+            {
+                return false;
+            }
+
+            _rawUrl = url;
+            if (_rawUrl.EndsWith("/", StringComparison.Ordinal))
+            {
+                _rawUrl = _rawUrl.TrimEnd('/');
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/GitLink/Providers/ProviderManager.cs
+++ b/src/GitLink/Providers/ProviderManager.cs
@@ -14,7 +14,7 @@ namespace GitLink.Providers
     {
         public ProviderBase GetProvider(string url)
         {
-            var providerTypes = TypeCache.GetTypes(x => typeof(ProviderBase).IsAssignableFromEx(x) && !x.IsAbstract);
+            var providerTypes = TypeCache.GetTypes(x => typeof(ProviderBase).IsAssignableFromEx(x) && !x.IsAbstract && x != typeof(CustomRawUrlProvider));
 
             var typeFactory = TypeFactory.Default;
 
@@ -25,6 +25,12 @@ namespace GitLink.Providers
                 {
                     return provider;
                 }
+            }
+
+            var customProvider = typeFactory.CreateInstance<CustomRawUrlProvider>();
+            if (customProvider.Initialize(url))
+            {
+                return customProvider;
             }
 
             return null;


### PR DESCRIPTION
The feature in this PR can be used to tackle a number of open scenarios:

1. Users of standard github/bitbucket that want/need to expose file content via a different URL (i.e. my use of the [proxy server](https://github.com/GitTools/GitLink/issues/37#issuecomment-154583909) to work around github's 401 obfuscation)
2. Users of on-prem deployments of github/bitbucket (e.g. https://github.com/GitTools/GitLink/issues/66)
3. Users of any other git-based VCS (at least as long as that system exposes an HTTP/HTTPS endpoint for accessing raw content that conforms to the following patter `{rootUrl}/{revision}/{relativeFilePath}` - as encoded in the inner workings of [Linker.cs](https://github.com/GitTools/GitLink/blob/692068d71da900f60fd69843d7e66b959c807995/src/GitLink/Linker.cs#L202))

The solution is to introduce a fallback provider that uses the `TargetUrl` parameter as the `{rootUrl}` in that raw content access pattern. The usage would be as follows:

    GitLink.exe c:\source\GitLink -u https://raw.githubusercontent.com/GitTools/GitLink