### PR TITLE
Added support to specify what projects to include

### DIFF
--- a/src/GitLink.Tests/ArgumentParserFacts.cs
+++ b/src/GitLink.Tests/ArgumentParserFacts.cs
@@ -120,6 +120,21 @@ namespace GitLink.Tests
         }
 
         [TestCase]
+        public void CorrectlyParsesIncludedProjects()
+        {
+            var context = ArgumentParser.ParseArguments("solutionDirectory -u http://github.com/CatenaLogic/GitLink -debug -c someConfiguration -include test1,test2");
+
+            Assert.AreEqual("solutionDirectory", context.SolutionDirectory);
+            Assert.AreEqual("http://github.com/CatenaLogic/GitLink", context.TargetUrl);
+            Assert.AreEqual("someConfiguration", context.ConfigurationName);
+            Assert.IsTrue(context.IsDebug);
+
+            Assert.AreEqual(2, context.IncludedProjects.Count);
+            Assert.AreEqual("test1", context.IncludedProjects[0]);
+            Assert.AreEqual("test2", context.IncludedProjects[1]);
+        }
+
+        [TestCase]
         public void ThrowsExceptionForUnknownArgument()
         {
             ExceptionTester.CallMethodAndExpectException<GitLinkException>(() => ArgumentParser.ParseArguments("solutionDirectory -x logFilePath"));

--- a/src/GitLink/ArgumentParser.cs
+++ b/src/GitLink/ArgumentParser.cs
@@ -134,6 +134,12 @@ namespace GitLink
                     continue;
                 }
 
+                if (IsSwitch("include", name))
+                {
+                    context.IncludedProjects.AddRange(value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
+                    continue;
+                }
+
                 if (IsSwitch("ignore", name))
                 {
                     context.IgnoredProjects.AddRange(value.Split(new []{ ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));

--- a/src/GitLink/Context.cs
+++ b/src/GitLink/Context.cs
@@ -31,6 +31,7 @@ namespace GitLink
             Authentication = new Authentication();
             ConfigurationName = "Release";
             PlatformName = "AnyCPU";
+            IncludedProjects = new List<string>();
             IgnoredProjects = new List<string>();
         }
 
@@ -91,6 +92,8 @@ namespace GitLink
         public string ShaHash { get; set; }
 
         public string SolutionFile { get; set; }
+
+        public List<string> IncludedProjects { get; private set; }
 
         public List<string> IgnoredProjects { get; private set; }
 

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -20,20 +20,20 @@ namespace GitLink
     {
         private static readonly ILog Log = LogManager.GetCurrentClassLogger();
 
-        public static bool ShouldBeIgnored(this Project project, IEnumerable<string> projectsToIgnore)
+        public static bool ShouldBeIgnored(this Project project, ICollection<string> projectsToInclude, ICollection<string> projectsToIgnore)
         {
             Argument.IsNotNull(() => project);
 
             var projectName = GetProjectName(project).ToLower();
 
-            foreach (var projectToIgnore in projectsToIgnore)
+            if (projectsToIgnore.Any(projectToIgnore => string.Equals(projectName, projectToIgnore, StringComparison.InvariantCultureIgnoreCase)))
             {
-                var lowerCaseProjectToIgnore = projectToIgnore.ToLower();
+                return true;
+            }
 
-                if (string.Equals(projectName, lowerCaseProjectToIgnore))
-                {
-                    return true;
-                }
+            if (projectsToInclude.Count > 0 && !projectsToInclude.Any(projectToInclude => string.Equals(projectName, projectToInclude, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                return true;
             }
 
             return false;

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -96,7 +96,7 @@ namespace GitLink
                     {
                         try
                         {
-                            if (project.ShouldBeIgnored(context.IgnoredProjects))
+                            if (project.ShouldBeIgnored(context.IncludedProjects, context.IgnoredProjects))
                             {
                                 Log.Info("Ignoring '{0}'", project.GetProjectName());
                                 Log.Info(string.Empty);


### PR DESCRIPTION
My projects are using specific separate folders for the outputs, so I need to run GitLink separately for each one of them.

As such, I've added a "-include" command line parameter that will allow to specify what project specifically we want to run GitLink for.