### PR TITLE
Support of placeholder ({filename} and {revision}) in the URL plus an option to use an indexing strategy that wouldn't rely on SRCSRV http support, but use a powershell command for URL download instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ When working with a repository using uncommon URL you can use placeholders to sp
     GitLink.exe c:\source\catel -u "https://host/projects/catel/repos/catel/browse/{filename}?at={revision}&raw"
     
 The custom url will be used to fill the placeholders with the relative file path and the revision hash.
+
 ## Running for a custom raw content URL
 
 When working with a content proxy or an alternative git VCS system that supports direct HTTP access to specific file revisions use the `-u` parameter with the custom raw content root URL

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ When specific projects should be ignored, use the *-ignore* option. This option 
 
 	GitLink.exe c:\source\catel -u https://github.com/catel/catel -f Catel.sln -ignore Catel.Core.WP80,Catel.MVVM.WP80
 
+## Running for an uncommon / customized URL
+
+When working with a repository using uncommon URL you can use placeholders to specifiy where the filename and revision hash should be, use `-u` parameter with the custom URL
+
+    GitLink.exe c:\source\catel -u "https://host/projects/catel/repos/catel/browse/{filename}?at={revision}&raw"
+    
+The custom url will be used to fill the placeholders with the relative file path and the revision hash.
 ## Running for a custom raw content URL
 
 When working with a content proxy or an alternative git VCS system that supports direct HTTP access to specific file revisions use the `-u` parameter with the custom raw content root URL

--- a/src/GitLink.Tests/ArgumentParserFacts.cs
+++ b/src/GitLink.Tests/ArgumentParserFacts.cs
@@ -124,5 +124,13 @@ namespace GitLink.Tests
         {
             ExceptionTester.CallMethodAndExpectException<GitLinkException>(() => ArgumentParser.ParseArguments("solutionDirectory -x logFilePath"));
         }
+
+        [TestCase]
+        public void PowershellDownloadSetToTrue()
+        {
+            var context = ArgumentParser.ParseArguments("solutionDirectory -u http://github.com/CatenaLogic/GitLink -powershell");
+
+            Assert.IsTrue(context.DownloadWithPowershell);
+        }
     }
 }

--- a/src/GitLink.Tests/GitLink.Tests.csproj
+++ b/src/GitLink.Tests/GitLink.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="GlobalInitialization.cs" />
     <Compile Include="Providers\BitBucketProviderFacts.cs" />
     <Compile Include="Providers\CustomRawUrlProviderFacts.cs" />
+    <Compile Include="Providers\CustomUrlProviderFacts.cs" />
     <Compile Include="Providers\GitHubProviderFacts.cs" />
     <Compile Include="Providers\ProviderManagerFacts.cs" />
   </ItemGroup>

--- a/src/GitLink.Tests/Providers/CustomUrlProviderFacts.cs
+++ b/src/GitLink.Tests/Providers/CustomUrlProviderFacts.cs
@@ -1,13 +1,13 @@
-﻿using GitLink.Providers;
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace GitLink.Tests.Providers
+﻿namespace GitLink.Tests.Providers
 {
+    using GitLink.Providers;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
     public class CustomUrlProviderFacts
     {
         private const string correctUrl = "https://bitbucket.intra.company.com/projects/aaa/repos/a/browse/{filename}?at={revision}&raw";

--- a/src/GitLink.Tests/Providers/CustomUrlProviderFacts.cs
+++ b/src/GitLink.Tests/Providers/CustomUrlProviderFacts.cs
@@ -1,0 +1,82 @@
+﻿using GitLink.Providers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitLink.Tests.Providers
+{
+    public class CustomUrlProviderFacts
+    {
+        private const string correctUrl = "https://bitbucket.intra.company.com/projects/aaa/repos/a/browse/{filename}?at={revision}&raw";
+        [TestFixture]
+        public class TheInitialization
+        {
+            [TestCase(correctUrl, true)]
+            [TestCase("https://example.com/repo", false)]
+            [TestCase("https://bitbucket.intra.company.com/projects/aaa/repos/a/browse/{filename}?raw", true)]
+            [TestCase("gopher://example.com/repo", false)]
+            public void CorrectlyValidatesForUrls(string url, bool expectedValue)
+            {
+                var provider = new CustomUrlProvider();
+                var valid = provider.Initialize(url);
+
+                Assert.AreEqual(expectedValue, valid);
+            }
+        }
+
+        [TestFixture]
+        public class TheGitHubProviderProperties
+        {
+            [TestCase]
+            public void ReturnsNullCompany()
+            {
+                var provider = new CustomUrlProvider();
+                provider.Initialize(correctUrl);
+
+                Assert.IsNull(provider.CompanyName);
+            }
+
+            [TestCase]
+            public void ReturnsNullCompanyUrl()
+            {
+                var provider = new CustomUrlProvider();
+                provider.Initialize(correctUrl);
+
+                Assert.IsNull(provider.CompanyUrl);
+            }
+
+            [TestCase]
+            public void ReturnsNullProject()
+            {
+                var provider = new CustomUrlProvider();
+                provider.Initialize(correctUrl);
+
+                Assert.IsNull(provider.ProjectName);
+            }
+
+            [TestCase]
+            public void ReturnsNullProjectUrl()
+            {
+                var provider = new CustomUrlProvider();
+                provider.Initialize(correctUrl);
+
+                Assert.IsNull(provider.ProjectUrl);
+            }
+
+            [TestCase]
+            public void ReturnsValidRawGitUrl()
+            {
+                var provider = new CustomUrlProvider();
+                provider.Initialize(correctUrl);
+
+                string correctReturnedUrl = correctUrl.Replace("{filename}", "%var2%");
+                correctReturnedUrl = correctReturnedUrl.Replace("{revision}", "{0}");
+
+                Assert.AreEqual(correctReturnedUrl, provider.RawGitUrl);
+            }
+        }
+    }
+}

--- a/src/GitLink/ArgumentParser.cs
+++ b/src/GitLink/ArgumentParser.cs
@@ -80,6 +80,12 @@ namespace GitLink
                     continue;
                 }
 
+                if (IsSwitch("powershell", name))
+                {
+                    context.DownloadWithPowershell = true;
+                    continue;
+                }
+
                 // After this point, all arguments should have a value
                 index++;
                 var valueInfo = GetValue(namedArguments, index);

--- a/src/GitLink/Context.cs
+++ b/src/GitLink/Context.cs
@@ -34,7 +34,8 @@ namespace GitLink
             IgnoredProjects = new List<string>();
         }
 
-		public bool DownloadWithPowershell { get; set; } = false;
+		public bool DownloadWithPowershell { get; set; }
+
         public bool IsHelp { get; set; }
 
         public bool IsDebug { get; set; }

--- a/src/GitLink/Context.cs
+++ b/src/GitLink/Context.cs
@@ -34,6 +34,7 @@ namespace GitLink
             IgnoredProjects = new List<string>();
         }
 
+		public bool DownloadWithPowershell { get; set; } = false;
         public bool IsHelp { get; set; }
 
         public bool IsDebug { get; set; }

--- a/src/GitLink/CustomUrlProvider.cs
+++ b/src/GitLink/CustomUrlProvider.cs
@@ -1,0 +1,44 @@
+﻿namespace GitLink.Providers
+{
+    using GitTools.Git;
+    using System.Text.RegularExpressions;
+
+    public sealed class CustomUrlProvider : ProviderBase
+    {
+        private static readonly string fileNamePlaceHolder = "{filename}";
+        private static readonly string revisionPlaceHolder = "{revision}";
+        private readonly Regex _regexUrl = new Regex(@"https?://.+");
+
+        private string _rawUrl;
+
+        public CustomUrlProvider()
+            : base(new GitPreparer())
+        {
+        }
+
+        public override string RawGitUrl
+        {
+            get
+            {
+                return _rawUrl;
+            }
+        }
+
+        public override bool Initialize(string url)
+        {
+            if (string.IsNullOrEmpty(url) || !_regexUrl.IsMatch(url) ||(
+                !url.Contains(fileNamePlaceHolder) && !url.Contains(revisionPlaceHolder)))
+            {
+                return false;
+            }
+
+            if(url.Contains(fileNamePlaceHolder))
+                _rawUrl = url.Replace(fileNamePlaceHolder, "%var2%");
+
+            if(url.Contains(revisionPlaceHolder))
+                _rawUrl = _rawUrl.Replace(revisionPlaceHolder, "{0}");
+
+            return true;
+        }
+    }
+}

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -47,7 +47,7 @@ namespace GitLink
             return projectName ?? Path.GetFileName(project.FullPath);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths)
+        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, bool DownloadWithPowershell)
         {
             Argument.IsNotNull(() => project);
             Argument.IsNotNullOrWhitespace(() => rawUrl);
@@ -55,17 +55,17 @@ namespace GitLink
 
             var srcsrvFile = GetOutputSrcSrvFile(project);
 
-            CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile);
+            CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, DownloadWithPowershell);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile)
+        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile, bool DownloadWithPowershell)
         {
             Argument.IsNotNull(() => project);
             Argument.IsNotNullOrWhitespace(() => rawUrl);
             Argument.IsNotNullOrWhitespace(() => revision);
             Argument.IsNotNullOrWhitespace(() => srcsrvFile);
 
-            File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value))));
+            File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), DownloadWithPowershell));
         }
 
         public static IEnumerable<ProjectItem> GetCompilableItems(this Project project)

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -58,14 +58,14 @@ namespace GitLink
             CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, downloadWithPowershell);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile, bool DownloadWithPowershell)
+        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile, bool downloadWithPowershell)
         {
             Argument.IsNotNull(() => project);
             Argument.IsNotNullOrWhitespace(() => rawUrl);
             Argument.IsNotNullOrWhitespace(() => revision);
             Argument.IsNotNullOrWhitespace(() => srcsrvFile);
 
-            File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), DownloadWithPowershell));
+            File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), downloadWithPowershell));
         }
 
         public static IEnumerable<ProjectItem> GetCompilableItems(this Project project)

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -47,7 +47,7 @@ namespace GitLink
             return projectName ?? Path.GetFileName(project.FullPath);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, bool DownloadWithPowershell)
+        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, bool downloadWithPowershell)
         {
             Argument.IsNotNull(() => project);
             Argument.IsNotNullOrWhitespace(() => rawUrl);
@@ -55,7 +55,7 @@ namespace GitLink
 
             var srcsrvFile = GetOutputSrcSrvFile(project);
 
-            CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, DownloadWithPowershell);
+            CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, downloadWithPowershell);
         }
 
         public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile, bool DownloadWithPowershell)

--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Context.cs" />
     <Compile Include="Providers\BitBucketProvider.cs" />
     <Compile Include="Providers\CustomRawUrlProvider.cs" />
+    <Compile Include="Providers\CustomUrlProvider.cs" />
     <Compile Include="Providers\GitHubProvider.cs" />
     <Compile Include="Providers\Interfaces\IProviderManager.cs" />
     <Compile Include="Providers\Interfaces\IProvider.cs" />

--- a/src/GitLink/HelpWriter.cs
+++ b/src/GitLink/HelpWriter.cs
@@ -39,6 +39,8 @@ GitLink [solutionPath] -u [urlToRepository]
     -s [shaHash]       The SHA-1 hash of the commit.
     -d [pdbDirectory]  The directory where pdb files exists, default value 
                        is the normal project output directory.
+    -powershell        Use an indexing strategy that won't rely on SRCSRV http support,
+                       but use a powershell command for URL download instead.
     -errorsaswarnings  Don't fail on errors, but treat them as warnings instead.
     -skipverify        Skip pdb verification in case it causes issues (it's a formality anyway)
     -debug             Enables debug mode with special dumps of msbuild.

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -199,7 +199,13 @@ namespace GitLink
                     }
                 }
 
-                var rawUrl = string.Format("{0}/{{0}}/%var2%", context.Provider.RawGitUrl);
+				var rawUrl = context.Provider.RawGitUrl;
+
+                if(!rawUrl.Contains("%var2%") && !rawUrl.Contains("{0}"))
+                { 
+                    rawUrl= string.Format("{0}/{{0}}/%var2%", context.Provider.RawGitUrl);
+                }
+				
                 var paths = new Dictionary<string, string>();
                 foreach (var compilable in compilables)
                 {
@@ -212,7 +218,7 @@ namespace GitLink
                     paths.Add(compilable, relativePathForUrl);
                 }
 
-                project.CreateSrcSrv(rawUrl, shaHash, paths, projectSrcSrvFile);
+                project.CreateSrcSrv(rawUrl, shaHash, paths, projectSrcSrvFile, context.DownloadWithPowershell);
 
                 Log.Debug("Created source server link file, updating pdb file '{0}'", context.GetRelativePath(projectPdbFile));
 

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -203,7 +203,7 @@ namespace GitLink
 
                 if(!rawUrl.Contains("%var2%") && !rawUrl.Contains("{0}"))
                 { 
-                    rawUrl= string.Format("{0}/{{0}}/%var2%", context.Provider.RawGitUrl);
+                    rawUrl= string.Format("{0}/{{0}}/%var2%", rawUrl);
                 }
 				
                 var paths = new Dictionary<string, string>();

--- a/src/GitLink/Pdb/SrcSrv.cs
+++ b/src/GitLink/Pdb/SrcSrv.cs
@@ -19,7 +19,7 @@ namespace GitLink.Pdb
             return string.Format(rawUrl, revision);
         }
 
-        public static byte[] Create(string rawUrl, string revision, IEnumerable<Tuple<string, string>> paths, bool DebugWithPowershell)
+        public static byte[] Create(string rawUrl, string revision, IEnumerable<Tuple<string, string>> paths, bool downloadWithPowershell)
         {
             Argument.IsNotNullOrWhitespace(() => rawUrl);
             Argument.IsNotNullOrWhitespace(() => revision);
@@ -34,11 +34,11 @@ namespace GitLink.Pdb
                     sw.WriteLine("VERSION=2");
                     sw.WriteLine("SRCSRV: variables ------------------------------------------");                    
                     sw.WriteLine("RAWURL={0}", CreateTarget(rawUrl, revision));
-                    if(DebugWithPowershell)
+                    if(downloadWithPowershell)
                     {
                         sw.WriteLine("TRGFILE=%fnbksl%(%targ%%var2%)");
                         sw.WriteLine("SRCSRVTRG=%TRGFILE%");
-                        sw.WriteLine("SRCSRVCMD=powershell -NoProfile -Command \"(New-Object system.net.WebClient).DownloadFile('%RAWURL%', '%TRGFILE%')\"");
+                        sw.WriteLine("SRCSRVCMD=powershell -NoProfile -Command \"(New-Object System.Net.WebClient).DownloadFile('%RAWURL%', '%TRGFILE%')\"");
                     }
                     else
                     {

--- a/src/GitLink/Pdb/SrcSrv.cs
+++ b/src/GitLink/Pdb/SrcSrv.cs
@@ -19,7 +19,7 @@ namespace GitLink.Pdb
             return string.Format(rawUrl, revision);
         }
 
-        public static byte[] Create(string rawUrl, string revision, IEnumerable<Tuple<string, string>> paths)
+        public static byte[] Create(string rawUrl, string revision, IEnumerable<Tuple<string, string>> paths, bool DebugWithPowershell)
         {
             Argument.IsNotNullOrWhitespace(() => rawUrl);
             Argument.IsNotNullOrWhitespace(() => revision);
@@ -29,12 +29,22 @@ namespace GitLink.Pdb
                 using (var sw = new StreamWriter(ms))
                 {
                     var scheme = new Uri(rawUrl).Scheme;
-
+                
                     sw.WriteLine("SRCSRV: ini ------------------------------------------------");
                     sw.WriteLine("VERSION=2");
-                    sw.WriteLine("SRCSRV: variables ------------------------------------------");
-                    sw.WriteLine("SRCSRVVERCTRL={0}", scheme);
-                    sw.WriteLine("SRCSRVTRG={0}", CreateTarget(rawUrl, revision));
+                    sw.WriteLine("SRCSRV: variables ------------------------------------------");                    
+                    sw.WriteLine("RAWURL={0}", CreateTarget(rawUrl, revision));
+                    if(DebugWithPowershell)
+                    {
+                        sw.WriteLine("TRGFILE=%fnbksl%(%targ%%var2%)");
+                        sw.WriteLine("SRCSRVTRG=%TRGFILE%");
+                        sw.WriteLine("SRCSRVCMD=powershell -NoProfile -Command \"(New-Object system.net.WebClient).DownloadFile('%RAWURL%', '%TRGFILE%')\"");
+                    }
+                    else
+                    {
+                        sw.WriteLine("SRCSRVVERCTRL={0}", scheme);
+                        sw.WriteLine("SRCSRVTRG=%RAWURL%");
+                    }
                     sw.WriteLine("SRCSRV: source files ---------------------------------------");
 
                     foreach (var tuple in paths)

--- a/src/GitLink/ProviderManager.cs
+++ b/src/GitLink/ProviderManager.cs
@@ -1,0 +1,45 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ProviderManager.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2014 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace GitLink.Providers
+{
+    using Catel.IoC;
+    using Catel.Reflection;
+
+    public class ProviderManager : IProviderManager
+    {
+        public ProviderBase GetProvider(string url)
+        {
+            var providerTypes = TypeCache.GetTypes(x => typeof(ProviderBase).IsAssignableFromEx(x) && !x.IsAbstract && x != typeof(CustomRawUrlProvider) && x != typeof(CustomUrlProvider));
+
+            var typeFactory = TypeFactory.Default;
+
+            var customUrlProvider = typeFactory.CreateInstance<CustomUrlProvider>();
+            if (customUrlProvider.Initialize(url))
+            {
+                return customUrlProvider;
+            }
+
+            foreach (var providerType in providerTypes)
+            {
+                var provider = (ProviderBase) typeFactory.CreateInstance(providerType);
+                if (provider.Initialize(url))
+                {
+                    return provider;
+                }
+            }            
+
+            var customProvider = typeFactory.CreateInstance<CustomRawUrlProvider>();
+            if (customProvider.Initialize(url))
+            {
+                return customProvider;
+            }
+
+           return null;
+        }
+    }
+}

--- a/src/GitLink/Providers/CustomUrlProvider.cs
+++ b/src/GitLink/Providers/CustomUrlProvider.cs
@@ -5,8 +5,8 @@
 
     public sealed class CustomUrlProvider : ProviderBase
     {
-        private static readonly string fileNamePlaceHolder = "{filename}";
-        private static readonly string revisionPlaceHolder = "{revision}";
+        private const string FileNamePlaceHolder = "{filename}";
+        private const string RevisionPlaceHolder = "{revision}";
         private readonly Regex _regexUrl = new Regex(@"https?://.+");
 
         private string _rawUrl;
@@ -27,16 +27,20 @@
         public override bool Initialize(string url)
         {
             if (string.IsNullOrEmpty(url) || !_regexUrl.IsMatch(url) ||(
-                !url.Contains(fileNamePlaceHolder) && !url.Contains(revisionPlaceHolder)))
+                !url.Contains(FileNamePlaceHolder) && !url.Contains(RevisionPlaceHolder)))
             {
                 return false;
             }
 
-            if(url.Contains(fileNamePlaceHolder))
-                _rawUrl = url.Replace(fileNamePlaceHolder, "%var2%");
+            if(url.Contains(FileNamePlaceHolder))
+            { 
+                _rawUrl = url.Replace(FileNamePlaceHolder, "%var2%");
+            }
 
-            if(url.Contains(revisionPlaceHolder))
-                _rawUrl = _rawUrl.Replace(revisionPlaceHolder, "{0}");
+            if (url.Contains(RevisionPlaceHolder))
+            { 
+                _rawUrl = _rawUrl.Replace(RevisionPlaceHolder, "{0}");
+            }
 
             return true;
         }

--- a/src/GitLink/Providers/CustomUrlProvider.cs
+++ b/src/GitLink/Providers/CustomUrlProvider.cs
@@ -26,8 +26,8 @@
 
         public override bool Initialize(string url)
         {
-            if (string.IsNullOrEmpty(url) || !_regexUrl.IsMatch(url) ||(
-                !url.Contains(FileNamePlaceHolder) && !url.Contains(RevisionPlaceHolder)))
+            if (string.IsNullOrEmpty(url) || !_regexUrl.IsMatch(url) || 
+               (!url.Contains(FileNamePlaceHolder) && !url.Contains(RevisionPlaceHolder)))
             {
                 return false;
             }


### PR DESCRIPTION
I tried to implement the functionality mentioned in the issue #66

I did pretty much the same thing as Marcind with his CustomRawUrlProvider, here is the readme part.

Running for an uncommon URL

When working with a repository using uncommon URL you can use placeholders to specifiy where the filename and revision hash should be, use -u parameter with the custom URL

       GitLink.exe c:\source\catel -u "https://host/projects/catel/repos/catel/browse/{filename}?at={revision}&raw"

The custom url will be used to fill the placeholders with the relative file path and the revision hash.

I also added an option to download the sources with powershell because SRCSRV http support doesn't accept characters like "?" thus another option was needed