### PR TITLE
Add support for Visual Studio Team Services #53

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@
 # Please keep the list sorted.
 
 Geert van Horrik <geert@catenalogic.com>
+Wesley Eledui <wefilmer@gmail.com>

--- a/src/GitLink.Tests/Providers/VisualStudioTeamServicesProviderFacts.cs
+++ b/src/GitLink.Tests/Providers/VisualStudioTeamServicesProviderFacts.cs
@@ -1,0 +1,104 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GitHubProviderFacts.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2014 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace GitLink.Tests.Providers
+{
+    using GitLink.Providers;
+    using NUnit.Framework;
+
+    public class VisualStudioTeamServicesProviderFacts
+    {
+        [TestFixture]
+        public class TheVisualStudioTeamServicesProviderInitialization
+        {
+            [TestCase]
+            public void ReturnsValidInitialization()
+            {
+                var provider = new VisualStudioTeamServicesProvider();
+                var valid = provider.Initialize("https://my-account.visualstudio.com/_git/main-repo");
+
+                Assert.IsTrue(valid);
+            }
+
+            [TestCase]
+            public void ReturnsInValidInitialization()
+            {
+                var provider = new VisualStudioTeamServicesProvider();
+                var valid = provider.Initialize("https://github.com/CatenaLogic/GitLink");
+
+                Assert.IsFalse(valid);
+            }
+
+            [TestFixture]
+            public class TheVisualStudioTeamServicesProviderProperties
+            {
+                [TestCase]
+                public void ReturnsValidCompany()
+                {
+                    var provider = new VisualStudioTeamServicesProvider();
+                    provider.Initialize("https://CatenaLogic.visualstudio.com/_git/main-repo");
+
+                    Assert.AreEqual("CatenaLogic", provider.CompanyName);
+                }
+
+                [TestCase]
+                public void ReturnsValidCompanyUrl()
+                {
+                    var provider = new VisualStudioTeamServicesProvider();
+                    provider.Initialize("https://CatenaLogic.visualstudio.com/_git/main-repo");
+
+                    Assert.AreEqual("https://CatenaLogic.visualstudio.com/DefaultCollection/", provider.CompanyUrl);
+                }
+
+                [TestCase]
+                public void ReturnsValidProject()
+                {
+                    var provider = new VisualStudioTeamServicesProvider();
+                    provider.Initialize("https://CatenaLogic.visualstudio.com/_git/main-repo");
+
+                    Assert.AreEqual("main-repo", provider.ProjectName);
+                }
+
+                [TestCase]
+                public void ReturnsValidProject2()
+                {
+                    var provider = new VisualStudioTeamServicesProvider();
+                    provider.Initialize("https://CatenaLogic.visualstudio.com/BigProject/_git/main-repo");
+
+                    Assert.AreEqual("BigProject", provider.ProjectName);
+                }
+
+                [TestCase]
+                public void ReturnsValidProjectUrl()
+                {
+                    var provider = new VisualStudioTeamServicesProvider();
+                    provider.Initialize("https://CatenaLogic.visualstudio.com/Project/_git/main-repo");
+
+                    Assert.AreEqual("https://CatenaLogic.visualstudio.com/Project/", provider.ProjectUrl);
+                }
+
+                [TestCase]
+                public void ReturnsValidProjectUrlWhenContainsPeriod()
+                {
+                    var provider = new VisualStudioTeamServicesProvider();
+                    provider.Initialize("https://CatenaLogic.visualstudio.com/Big.Project/_git/main.repo");
+
+                    Assert.AreEqual("https://CatenaLogic.visualstudio.com/Big.Project/", provider.ProjectUrl);
+                }
+
+                [TestCase]
+                public void ReturnsValidCompanyUrlWhenContainsPeriod()
+                {
+                    var provider = new VisualStudioTeamServicesProvider();
+                    provider.Initialize("https://Catena.Logic.visualstudio.com/BigProject/_git/main-repo");
+
+                    Assert.AreEqual("https://Catena.Logic.visualstudio.com/BigProject/", provider.ProjectUrl);
+                }
+
+            }
+        }
+    }
+}

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -31,6 +31,7 @@ namespace GitLink
         public static void CreateSrcSrv(this Project project, SrcSrvContext srcSrvContext)
         {
             Argument.IsNotNull(() => project);
+            Argument.IsNotNull(() => srcSrvContext);
             Argument.IsNotNullOrWhitespace(() => srcSrvContext.RawUrl);
             Argument.IsNotNullOrWhitespace(() => srcSrvContext.Revision);
 
@@ -42,6 +43,7 @@ namespace GitLink
         public static void CreateSrcSrv(this Project project, string srcsrvFile, SrcSrvContext srcSrvContext)
         {
             Argument.IsNotNull(() => project);
+            Argument.IsNotNull(() => srcSrvContext);
             Argument.IsNotNullOrWhitespace(() => srcSrvContext.RawUrl);
             Argument.IsNotNullOrWhitespace(() => srcSrvContext.Revision);
             Argument.IsNotNullOrWhitespace(() => srcsrvFile);

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -28,31 +28,31 @@ namespace GitLink
             return projectName ?? Path.GetFileName(project.FullPath);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, bool downloadWithPowershell, SrcSrvContext srcSrvContext)
+        public static void CreateSrcSrv(this Project project, SrcSrvContext srcSrvContext)
         {
             Argument.IsNotNull(() => project);
-            Argument.IsNotNullOrWhitespace(() => rawUrl);
-            Argument.IsNotNullOrWhitespace(() => revision);
+            Argument.IsNotNullOrWhitespace(() => srcSrvContext.RawUrl);
+            Argument.IsNotNullOrWhitespace(() => srcSrvContext.Revision);
 
             var srcsrvFile = GetOutputSrcSrvFile(project);
 
-            CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, downloadWithPowershell, srcSrvContext);
+            CreateSrcSrv(project, srcsrvFile, srcSrvContext);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile, bool downloadWithPowershell, SrcSrvContext srcSrvContext)
+        public static void CreateSrcSrv(this Project project, string srcsrvFile, SrcSrvContext srcSrvContext)
         {
             Argument.IsNotNull(() => project);
-            Argument.IsNotNullOrWhitespace(() => rawUrl);
-            Argument.IsNotNullOrWhitespace(() => revision);
+            Argument.IsNotNullOrWhitespace(() => srcSrvContext.RawUrl);
+            Argument.IsNotNullOrWhitespace(() => srcSrvContext.Revision);
             Argument.IsNotNullOrWhitespace(() => srcsrvFile);
 
             if (srcSrvContext.VstsData.Count != 0)
             {
-                File.WriteAllBytes(srcsrvFile, SrcSrv.CreateVsts(revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), srcSrvContext.VstsData));
+                File.WriteAllBytes(srcsrvFile, SrcSrv.CreateVsts(srcSrvContext.Revision, srcSrvContext.Paths, srcSrvContext.VstsData));
             }
             else
             {
-                File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), downloadWithPowershell));
+                File.WriteAllBytes(srcsrvFile, SrcSrv.Create(srcSrvContext.RawUrl, srcSrvContext.Revision, srcSrvContext.Paths, srcSrvContext.DownloadWithPowershell));
             }
         }
 

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -28,7 +28,7 @@ namespace GitLink
             return projectName ?? Path.GetFileName(project.FullPath);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, bool downloadWithPowershell, Dictionary<string, string> vstsData = null)
+        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, bool downloadWithPowershell, SrcSrvContext srcSrvContext)
         {
             Argument.IsNotNull(() => project);
             Argument.IsNotNullOrWhitespace(() => rawUrl);
@@ -36,33 +36,24 @@ namespace GitLink
 
             var srcsrvFile = GetOutputSrcSrvFile(project);
 
-            if(vstsData != null)
-            {
-                CreateSrcSrv(project, revision, paths, srcsrvFile, vstsData);
-            }
-            else
-            {
-                CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, downloadWithPowershell);
-            }
+            CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, downloadWithPowershell, srcSrvContext);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile, bool downloadWithPowershell)
+        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile, bool downloadWithPowershell, SrcSrvContext srcSrvContext)
         {
             Argument.IsNotNull(() => project);
             Argument.IsNotNullOrWhitespace(() => rawUrl);
             Argument.IsNotNullOrWhitespace(() => revision);
             Argument.IsNotNullOrWhitespace(() => srcsrvFile);
 
-            File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), downloadWithPowershell));
-        }
-
-        public static void CreateSrcSrv(this Project project, string revision, Dictionary<string, string> paths, string srcsrvFile, Dictionary<string, string> vstsData)
-        {
-            Argument.IsNotNull(() => project);
-            Argument.IsNotNullOrWhitespace(() => revision);
-            Argument.IsNotNullOrWhitespace(() => srcsrvFile);
-
-            File.WriteAllBytes(srcsrvFile, SrcSrv.CreateVsts(revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), vstsData));
+            if (srcSrvContext.VstsData.Count != 0)
+            {
+                File.WriteAllBytes(srcsrvFile, SrcSrv.CreateVsts(revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), srcSrvContext.VstsData));
+            }
+            else
+            {
+                File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), downloadWithPowershell));
+            }
         }
 
         public static IEnumerable<ProjectItem> GetCompilableItems(this Project project)

--- a/src/GitLink/Extensions/ProjectExtensions.cs
+++ b/src/GitLink/Extensions/ProjectExtensions.cs
@@ -28,7 +28,7 @@ namespace GitLink
             return projectName ?? Path.GetFileName(project.FullPath);
         }
 
-        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, bool downloadWithPowershell)
+        public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, bool downloadWithPowershell, Dictionary<string, string> vstsData = null)
         {
             Argument.IsNotNull(() => project);
             Argument.IsNotNullOrWhitespace(() => rawUrl);
@@ -36,7 +36,14 @@ namespace GitLink
 
             var srcsrvFile = GetOutputSrcSrvFile(project);
 
-            CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, downloadWithPowershell);
+            if(vstsData != null)
+            {
+                CreateSrcSrv(project, revision, paths, srcsrvFile, vstsData);
+            }
+            else
+            {
+                CreateSrcSrv(project, rawUrl, revision, paths, srcsrvFile, downloadWithPowershell);
+            }
         }
 
         public static void CreateSrcSrv(this Project project, string rawUrl, string revision, Dictionary<string, string> paths, string srcsrvFile, bool downloadWithPowershell)
@@ -47,6 +54,15 @@ namespace GitLink
             Argument.IsNotNullOrWhitespace(() => srcsrvFile);
 
             File.WriteAllBytes(srcsrvFile, SrcSrv.Create(rawUrl, revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), downloadWithPowershell));
+        }
+
+        public static void CreateSrcSrv(this Project project, string revision, Dictionary<string, string> paths, string srcsrvFile, Dictionary<string, string> vstsData)
+        {
+            Argument.IsNotNull(() => project);
+            Argument.IsNotNullOrWhitespace(() => revision);
+            Argument.IsNotNullOrWhitespace(() => srcsrvFile);
+
+            File.WriteAllBytes(srcsrvFile, SrcSrv.CreateVsts(revision, paths.Select(x => new Tuple<string, string>(x.Key, x.Value)), vstsData));
         }
 
         public static IEnumerable<ProjectItem> GetCompilableItems(this Project project)

--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Providers\Interfaces\IProvider.cs" />
     <Compile Include="Providers\ProviderBase.cs" />
     <Compile Include="Providers\ProviderManager.cs" />
+    <Compile Include="Providers\VisualStudioTeamServicesProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Pdb\PdbRoot.cs" />
     <Compile Include="Pdb\PdbStream.cs" />
     <Compile Include="Pdb\SrcSrv.cs" />
+    <Compile Include="Pdb\SrcSrvContext.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Context.cs" />

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -185,10 +185,12 @@ namespace GitLink
                 var projectPdbFile = pathPdbDirectory != null ? Path.Combine(pathPdbDirectory, Path.GetFileName(outputPdbFile)) : Path.GetFullPath(outputPdbFile);
                 var projectSrcSrvFile = projectPdbFile + ".srcsrv";
 
-                var srcSrvContext = new SrcSrvContext();
-                srcSrvContext.Revision = shaHash;
-                srcSrvContext.RawUrl = context.Provider.RawGitUrl;
-                srcSrvContext.DownloadWithPowershell = context.DownloadWithPowershell;
+                var srcSrvContext = new SrcSrvContext
+                {
+                    Revision = shaHash,
+                    RawUrl = context.Provider.RawGitUrl,
+                    DownloadWithPowershell = context.DownloadWithPowershell
+                };
 
                 if (!File.Exists(projectPdbFile))
                 {

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -16,6 +16,7 @@ namespace GitLink
     using Catel.Logging;
     using GitTools;
     using Microsoft.Build.Evaluation;
+    using Pdb;
 
     /// <summary>
     /// Class Linker.
@@ -219,20 +220,17 @@ namespace GitLink
                     paths.Add(compilable, relativePathForUrl);
                 }
 
-                // When using the VisualStudioTeamServicesProvider, create dictionary with VSTS-specific data
+                var srcSrvContext = new SrcSrvContext();
+
+                // When using the VisualStudioTeamServicesProvider, add extra infomration to dictionary with VSTS-specific data
                 if (context.Provider.GetType().Name.EqualsIgnoreCase("VisualStudioTeamServicesProvider"))
                 {
-                    var vstsData = new Dictionary<string, string> { };
-                    vstsData["TFS_COLLECTION"] = context.Provider.CompanyUrl;
-                    vstsData["TFS_TEAM_PROJECT"] = context.Provider.ProjectName;
-                    vstsData["TFS_REPO"] = context.Provider.ProjectName;
+                    srcSrvContext.VstsData["TFS_COLLECTION"] = context.Provider.CompanyUrl;
+                    srcSrvContext.VstsData["TFS_TEAM_PROJECT"] = context.Provider.ProjectName;
+                    srcSrvContext.VstsData["TFS_REPO"] = context.Provider.ProjectName;
+                }
 
-                    project.CreateSrcSrv(shaHash, paths, projectSrcSrvFile, vstsData);
-                }
-                else
-                {
-                    project.CreateSrcSrv(rawUrl, shaHash, paths, projectSrcSrvFile, context.DownloadWithPowershell);
-                }
+                project.CreateSrcSrv(rawUrl, shaHash, paths, projectSrcSrvFile, context.DownloadWithPowershell, srcSrvContext);
 
                 Log.Debug("Created source server link file, updating pdb file '{0}'", context.GetRelativePath(projectPdbFile));
 

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -219,7 +219,20 @@ namespace GitLink
                     paths.Add(compilable, relativePathForUrl);
                 }
 
-                project.CreateSrcSrv(rawUrl, shaHash, paths, projectSrcSrvFile, context.DownloadWithPowershell);
+                // When using the VisualStudioTeamServicesProvider, create dictionary with VSTS-specific data
+                if (context.Provider.GetType().Name.EqualsIgnoreCase("VisualStudioTeamServicesProvider"))
+                {
+                    var vstsData = new Dictionary<string, string> { };
+                    vstsData["TFS_COLLECTION"] = context.Provider.CompanyUrl;
+                    vstsData["TFS_TEAM_PROJECT"] = context.Provider.ProjectName;
+                    vstsData["TFS_REPO"] = context.Provider.ProjectName;
+
+                    project.CreateSrcSrv(shaHash, paths, projectSrcSrvFile, vstsData);
+                }
+                else
+                {
+                    project.CreateSrcSrv(rawUrl, shaHash, paths, projectSrcSrvFile, context.DownloadWithPowershell);
+                }
 
                 Log.Debug("Created source server link file, updating pdb file '{0}'", context.GetRelativePath(projectPdbFile));
 

--- a/src/GitLink/Pdb/SrcSrv.cs
+++ b/src/GitLink/Pdb/SrcSrv.cs
@@ -57,6 +57,67 @@ namespace GitLink.Pdb
                     sw.Flush();
 
                     return ms.ToArray();
+
+                }
+            }
+        }
+
+        public static byte[] CreateVsts(string revision, IEnumerable<Tuple<string, string>> paths, Dictionary<string, string> vstsData = null)
+        {
+            Argument.IsNotNullOrWhitespace(() => revision);
+
+            using (var ms = new MemoryStream())
+            {
+                using (var sw = new StreamWriter(ms))
+                {
+                    sw.WriteLine("SRCSRV: ini ------------------------------------------------");
+                    sw.WriteLine("VERSION=3");
+                    sw.WriteLine("INDEXVERSION=2");
+                    sw.WriteLine("VERCTRL=Team Foundation Server");
+                    sw.WriteLine("DATETIME={0}", string.Format("{0:ddd MMM hh:mm:ss yyyy}", DateTime.Now));
+                    sw.WriteLine("INDEXER=TFSTB");
+                    sw.WriteLine("SRCSRV: variables ------------------------------------------");
+                    sw.WriteLine("TFS_EXTRACT_TARGET=%targ%\\%var5%\\%fnvar%(%var6%)\\%fnbksl%(%var7%)");
+                    sw.WriteLine("TFS_EXTRACT_CMD=tf.exe git view /collection:%fnvar%(%var2%) /teamproject:\"%fnvar%(%var3%)\" /repository:\"%fnvar%(%var4%)\" /commitId:%fnvar%(%var5%) /path:\"%var7%\" /output:%SRCSRVTRG% %fnvar%(%var8%)");
+
+                    string tfs_collection;
+                    if (vstsData.TryGetValue("TFS_COLLECTION", out tfs_collection))
+                    {
+                        sw.WriteLine("TFS_COLLECTION={0}", tfs_collection);
+                    }
+
+                    string tfs_team_project;
+                    if (vstsData.TryGetValue("TFS_TEAM_PROJECT", out tfs_team_project))
+                    {
+                        sw.WriteLine("TFS_TEAM_PROJECT={0}", tfs_team_project);
+                    }
+
+                    string tfs_repo;
+                    if (vstsData.TryGetValue("TFS_REPO", out tfs_repo))
+                    {
+                        sw.WriteLine("TFS_REPO={0}", tfs_repo);
+                    }
+
+                    sw.WriteLine("TFS_COMMIT={0}", revision);
+                    sw.WriteLine("TFS_SHORT_COMMIT={0}", revision.Substring(0, 8));
+                    sw.WriteLine("TFS_APPLY_FILTERS=/applyfilters");
+                    sw.WriteLine("SRCSRVVERCTRL=git");
+                    sw.WriteLine("SRCSRVERRDESC=access");
+                    sw.WriteLine("SRCSRVERRVAR=var2");
+                    sw.WriteLine("SRCSRVTRG=%TFS_EXTRACT_TARGET%");
+                    sw.WriteLine("SRCSRVCMD=%TFS_EXTRACT_CMD%");
+                    sw.WriteLine("SRCSRV: source files ---------------------------------------");
+
+                    foreach (var tuple in paths)
+                    {
+                        sw.WriteLine("{0}*TFS_COLLECTION*TFS_TEAM_PROJECT*TFS_REPO*TFS_COMMIT*TFS_SHORT_COMMIT*{1}*TFS_APPLY_FILTERS", tuple.Item1, tuple.Item2);
+                    }
+
+                    sw.WriteLine("SRCSRV: end ------------------------------------------------");
+
+                    sw.Flush();
+
+                    return ms.ToArray();
                 }
             }
         }

--- a/src/GitLink/Pdb/SrcSrvContext.cs
+++ b/src/GitLink/Pdb/SrcSrvContext.cs
@@ -7,10 +7,26 @@
 
 namespace GitLink.Pdb
 {
+    using System;
     using System.Collections.Generic;
 
     public class SrcSrvContext
     {
-        public Dictionary<string, string> VstsData = new Dictionary<string, string>();
+        public SrcSrvContext()
+        {
+            Paths = new List<Tuple<string, string>>();
+            VstsData = new Dictionary<string, string>();
+
+        }
+
+        public string RawUrl { get; set; }
+
+        public bool DownloadWithPowershell { get; set; }
+
+        public string Revision { get; set; }
+
+        public List<Tuple<string, string>> Paths { get; private set; }
+
+        public Dictionary<string, string> VstsData { get; private set; }
     }
 }

--- a/src/GitLink/Pdb/SrcSrvContext.cs
+++ b/src/GitLink/Pdb/SrcSrvContext.cs
@@ -1,0 +1,16 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SrcSrvContext.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2016 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace GitLink.Pdb
+{
+    using System.Collections.Generic;
+
+    public class SrcSrvContext
+    {
+        public Dictionary<string, string> VstsData = new Dictionary<string, string>();
+    }
+}

--- a/src/GitLink/Providers/VisualStudioTeamServicesProvider.cs
+++ b/src/GitLink/Providers/VisualStudioTeamServicesProvider.cs
@@ -1,28 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Text.RegularExpressions;
-using GitTools.Git;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="VisualStudioTeamServicesProvider.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2016 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
 
 namespace GitLink.Providers
 {
+    using System;
+    using System.Text.RegularExpressions;
+    using Catel;
+    using GitTools.Git;
+
     public class VisualStudioTeamServicesProvider : ProviderBase
     {
         private readonly Regex _visualStudioTeamServicesRegex = new Regex(@"(?<url>(?<companyurl>(?:https://)?(?<accountname>([a-zA-Z0-9\-\.]*)?)\.visualstudio\.com/)(?<project>[a-zA-Z0-9\-\.]*)/?_git/(?<repo>[^/]+))");
 
-        public VisualStudioTeamServicesProvider() 
+        public VisualStudioTeamServicesProvider()
             : base(new GitPreparer())
         {
         }
 
         public override string RawGitUrl
         {
-            get
-            {
-                return "";
-            }
+            get { return string.Empty; }
         }
 
         public override bool Initialize(string url)
@@ -35,22 +36,22 @@ namespace GitLink.Providers
             }
 
             CompanyName = match.Groups["accountname"].Value;
-            CompanyUrl = match.Groups["companyurl"].Value + "DefaultCollection/";
+            CompanyUrl = match.Groups["companyurl"].Value;
 
             ProjectName = match.Groups["project"].Value;
-            if(ProjectName == "")
+            if (string.IsNullOrWhiteSpace(ProjectName))
             {
                 ProjectName = match.Groups["repo"].Value;
             }
 
             ProjectUrl = match.Groups["companyurl"].Value + ProjectName + "/";
 
-            if (!CompanyUrl.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase))
+            if (!CompanyUrl.StartsWithIgnoreCase("https://"))
             {
                 CompanyUrl = String.Concat("https://", CompanyUrl);
             }
 
-            if (!ProjectUrl.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase))
+            if (!ProjectUrl.StartsWithIgnoreCase("https://"))
             {
                 ProjectUrl = String.Concat("https://", ProjectUrl);
             }

--- a/src/GitLink/Providers/VisualStudioTeamServicesProvider.cs
+++ b/src/GitLink/Providers/VisualStudioTeamServicesProvider.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using GitTools.Git;
+
+namespace GitLink.Providers
+{
+    public class VisualStudioTeamServicesProvider : ProviderBase
+    {
+        private readonly Regex _visualStudioTeamServicesRegex = new Regex(@"(?<url>(?<companyurl>(?:https://)?(?<accountname>([a-zA-Z0-9\-\.]*)?)\.visualstudio\.com/)(?<project>[a-zA-Z0-9\-\.]*)/?_git/(?<repo>[^/]+))");
+
+        public VisualStudioTeamServicesProvider() 
+            : base(new GitPreparer())
+        {
+        }
+
+        public override string RawGitUrl
+        {
+            get
+            {
+                return "";
+            }
+        }
+
+        public override bool Initialize(string url)
+        {
+            var match = _visualStudioTeamServicesRegex.Match(url);
+
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            CompanyName = match.Groups["accountname"].Value;
+            CompanyUrl = match.Groups["companyurl"].Value + "DefaultCollection/";
+
+            ProjectName = match.Groups["project"].Value;
+            if(ProjectName == "")
+            {
+                ProjectName = match.Groups["repo"].Value;
+            }
+
+            ProjectUrl = match.Groups["companyurl"].Value + ProjectName + "/";
+
+            if (!CompanyUrl.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase))
+            {
+                CompanyUrl = String.Concat("https://", CompanyUrl);
+            }
+
+            if (!ProjectUrl.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase))
+            {
+                ProjectUrl = String.Concat("https://", ProjectUrl);
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Modified SrcSrv.cs to write a different form of data to the pdbs when vstsData is passed to the function.  this form includes using the SRCSRVCMD with "tf.exe git" to pull the source from Visual Studio Team Services. So when the Visual Studio Team Services provider is used, the project name and repository are extracted from the git url and this information is passed to the CreateSrcSrv function.