### PR TITLE
Mark nuget packages as development dependencies

### DIFF
--- a/deployment/NuGet/template/GitHubLink/GitHubLink.nuspec
+++ b/deployment/NuGet/template/GitHubLink/GitHubLink.nuspec
@@ -5,6 +5,7 @@
     <version>[VERSION]</version>
 	<title>GitHubLink</title>
     <authors>GeertvanHorrik</authors>
+    <DevelopmentDependency>True</DevelopmentDependency>
 	
 	<description>
 	  ** Note: this is a maintenance package, GitHubLink is replaced by GitLink **

--- a/deployment/NuGet/template/GitLink/GitLink.nuspec
+++ b/deployment/NuGet/template/GitLink/GitLink.nuspec
@@ -5,6 +5,7 @@
     <version>[VERSION]</version>
 	<title>GitLink</title>
     <authors>GeertvanHorrik</authors>
+    <DevelopmentDependency>True</DevelopmentDependency>
 	
 	<description>
 	  GitLink let's users step through your code hosted on any Git hosting service! This makes symbol servers obsolete which saves you both time 

--- a/deployment/NuGet/template/GitLinkTask/GitLinkTask.nuspec
+++ b/deployment/NuGet/template/GitLinkTask/GitLinkTask.nuspec
@@ -5,6 +5,7 @@
     <version>[VERSION]</version>
 	<title>GitLinkTask</title>
     <authors>GeertvanHorrik</authors>
+    <DevelopmentDependency>True</DevelopmentDependency>
 	
 	<description>
 	  GitLink let's users step through your code hosted on any Git hosting service! This makes symbol servers obsolete which saves you both time 


### PR DESCRIPTION
This prevents them from being required in the package being built that consumes these