### PR TITLE
Implementation of UNC provider with support for forward and back slas…

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 
 Geert van Horrik <geert@catenalogic.com>
 Wesley Eledui <wefilmer@gmail.com>
+Marek Fišera <mara@neptuo.com>

--- a/src/GitLink.Tests/GitLink.Tests.csproj
+++ b/src/GitLink.Tests/GitLink.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Providers\CustomUrlProviderFacts.cs" />
     <Compile Include="Providers\GitHubProviderFacts.cs" />
     <Compile Include="Providers\ProviderManagerFacts.cs" />
+    <Compile Include="Providers\UncProviderFacts.cs" />
     <Compile Include="Providers\VisualStudioTeamServicesProviderFacts.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GitLink.Tests/Providers/UncProviderFacts.cs
+++ b/src/GitLink.Tests/Providers/UncProviderFacts.cs
@@ -1,13 +1,15 @@
-﻿using GitLink.Providers;
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="UncProviderFacts.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2016 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
 
 namespace GitLink.Tests.Providers
 {
+    using GitLink.Providers;
+    using NUnit.Framework;
+
     /// <summary>
     /// Test cases for <see cref="UncProvider"/>.
     /// </summary>

--- a/src/GitLink.Tests/Providers/UncProviderFacts.cs
+++ b/src/GitLink.Tests/Providers/UncProviderFacts.cs
@@ -1,0 +1,47 @@
+﻿using GitLink.Providers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitLink.Tests.Providers
+{
+    /// <summary>
+    /// Test cases for <see cref="UncProvider"/>.
+    /// </summary>
+    public class UncProviderFacts
+    {
+        [TestFixture]
+        public class TheInitialization
+        {
+            [TestCase(@"//home/repo/{filename}", true)]
+            [TestCase(@"//home/repo/{revision}/{filename}", true)]
+            [TestCase(@"\\home\repo\{filename}", true)]
+            [TestCase(@"\\home\repo\{revision}\{filename}", true)]
+            [TestCase(@"//home/repo/", false)]
+            [TestCase(@"\\home\repo\", false)]
+            public void CorrectlyValidatesUncPath(string path, bool expectedValue)
+            {
+                var provider = new UncProvider();
+                var valid = provider.Initialize(path);
+
+                Assert.AreEqual(expectedValue, valid);
+            }
+
+            [TestCase(@"//home/repo/{filename}")]
+            [TestCase(@"//home/repo/{revision}/{filename}")]
+            [TestCase(@"\\home\repo\{filename}")]
+            [TestCase(@"\\home\repo\{revision}\{filename}")]
+            public void CorrenctlyReplacesPlaceHolders(string path)
+            {
+                var provider = new UncProvider();
+                Assert.IsTrue(provider.Initialize(path));
+
+                string expectedPath = path.Replace("{filename}", "%var2%").Replace("{revision}", "{0}");
+                Assert.AreEqual(expectedPath, provider.RawGitUrl);
+            }
+        }
+    }
+}

--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -120,10 +120,12 @@
     <Compile Include="Providers\CustomRawUrlProvider.cs" />
     <Compile Include="Providers\CustomUrlProvider.cs" />
     <Compile Include="Providers\GitHubProvider.cs" />
+    <Compile Include="Providers\Interfaces\IBackSlashSupport.cs" />
     <Compile Include="Providers\Interfaces\IProviderManager.cs" />
     <Compile Include="Providers\Interfaces\IProvider.cs" />
     <Compile Include="Providers\ProviderBase.cs" />
     <Compile Include="Providers\ProviderManager.cs" />
+    <Compile Include="Providers\UncProvider.cs" />
     <Compile Include="Providers\VisualStudioTeamServicesProvider.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -17,6 +17,7 @@ namespace GitLink
     using GitTools;
     using Microsoft.Build.Evaluation;
     using Pdb;
+    using Providers;
 
     /// <summary>
     /// Class Linker.
@@ -209,14 +210,14 @@ namespace GitLink
                     }
                 }
 
-                if(!srcSrvContext.RawUrl.Contains("%var2%") && !srcSrvContext.RawUrl.Contains("{0}"))
+                if (!srcSrvContext.RawUrl.Contains("%var2%") && !srcSrvContext.RawUrl.Contains("{0}"))
                 {
                     srcSrvContext.RawUrl = string.Format("{0}/{{0}}/%var2%", srcSrvContext.RawUrl);
                 }
-				
+
                 foreach (var compilable in compilables)
                 {
-                    var relativePathForUrl = compilable.Replace(context.SolutionDirectory, string.Empty).Replace("\\", "/");
+                    var relativePathForUrl = ReplaceSlashes(context.Provider, compilable.Replace(context.SolutionDirectory, string.Empty));
                     while (relativePathForUrl.StartsWith("/"))
                     {
                         relativePathForUrl = relativePathForUrl.Substring(1, relativePathForUrl.Length - 1);
@@ -251,6 +252,23 @@ namespace GitLink
             }
 
             return true;
+        }
+
+        private static string ReplaceSlashes(IProvider provider, string relativePathForUrl)
+        {
+            bool isBackSlashSupported = false;
+
+            // Check if provider is capable of determining whether to use back slashes or forward slashes.
+            IBackSlashSupport backSlashSupport = provider as IBackSlashSupport;
+            if (backSlashSupport != null)
+                isBackSlashSupported = backSlashSupport.IsBackSlashSupported;
+
+            if (isBackSlashSupported)
+                relativePathForUrl = relativePathForUrl.Replace("/", "\\");
+            else
+                relativePathForUrl = relativePathForUrl.Replace("\\", "/");
+
+            return relativePathForUrl;
         }
     }
 }

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -259,14 +259,20 @@ namespace GitLink
             bool isBackSlashSupported = false;
 
             // Check if provider is capable of determining whether to use back slashes or forward slashes.
-            IBackSlashSupport backSlashSupport = provider as IBackSlashSupport;
+            var backSlashSupport = provider as IBackSlashSupport;
             if (backSlashSupport != null)
+            {
                 isBackSlashSupported = backSlashSupport.IsBackSlashSupported;
+            }
 
             if (isBackSlashSupported)
+            {
                 relativePathForUrl = relativePathForUrl.Replace("/", "\\");
+            }
             else
+            {
                 relativePathForUrl = relativePathForUrl.Replace("\\", "/");
+            }
 
             return relativePathForUrl;
         }

--- a/src/GitLink/Providers/Interfaces/IBackSlashSupport.cs
+++ b/src/GitLink/Providers/Interfaces/IBackSlashSupport.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IBackSlashSupport.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2014 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
 
 namespace GitLink.Providers
 {

--- a/src/GitLink/Providers/Interfaces/IBackSlashSupport.cs
+++ b/src/GitLink/Providers/Interfaces/IBackSlashSupport.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitLink.Providers
+{
+    /// <summary>
+    /// Implementing this interface path resolver gives provider a change to determine 
+    /// if back slashes are supported or should be replaced.
+    /// </summary>
+    public interface IBackSlashSupport
+    {
+        /// <summary>
+        /// Gets whether back slashes in paths are supported or should be replaced.
+        /// </summary>
+        /// <value>
+        /// If value is <c>true</c>, back slashes are not replaced; otherwise back slahes are replaced by forward slashes.
+        /// </value>
+        bool IsBackSlashSupported { get; }
+    }
+}

--- a/src/GitLink/Providers/UncProvider.cs
+++ b/src/GitLink/Providers/UncProvider.cs
@@ -1,33 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using GitTools.Git;
-using System.Text.RegularExpressions;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="UncProvider.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2016 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
 
 namespace GitLink.Providers
 {
+    using GitTools.Git;
+    using System.Text.RegularExpressions;
+
     /// <summary>
     /// A git provider for UNC network paths.
     /// </summary>
     public class UncProvider : ProviderBase, IBackSlashSupport
     {
         /// <summary>
-        /// A class with placeholder constants.
+        /// Gets a placeholder for file name.
         /// </summary>
-        public static class PlaceHolder
-        {
-            /// <summary>
-            /// Gets a placeholder for file name.
-            /// </summary>
-            public const string FileName = "{filename}";
+        public const string FileNamePlaceHolder = "{filename}";
 
-            /// <summary>
-            /// Gets a placeholder for commit hash.
-            /// </summary>
-            public const string Revision = "{revision}";
-        }
+        /// <summary>
+        /// Gets a placeholder for commit hash.
+        /// </summary>
+        public const string RevisionPlaceHolder = "{revision}";
 
         private static readonly Regex _uncRegex = new Regex(@"^(//|\\).+");
         private string _rawUrl;
@@ -47,9 +43,13 @@ namespace GitLink.Providers
             get
             {
                 if (RawGitUrl.StartsWith("//"))
+                {
                     return false;
+                }
                 else
+                {
                     return true;
+                }
             }
         }
 
@@ -61,17 +61,17 @@ namespace GitLink.Providers
             }
 
             bool isMatch = false;
-            if(_uncRegex.IsMatch(url))
+            if (_uncRegex.IsMatch(url))
             {
-                if (url.Contains(PlaceHolder.FileName))
+                if (url.Contains(FileNamePlaceHolder))
                 {
-                    _rawUrl = url.Replace(PlaceHolder.FileName, "%var2%");
+                    _rawUrl = url.Replace(FileNamePlaceHolder, "%var2%");
                     isMatch = true;
                 }
 
-                if (url.Contains(PlaceHolder.Revision))
+                if (url.Contains(RevisionPlaceHolder))
                 {
-                    _rawUrl = _rawUrl.Replace(PlaceHolder.Revision, "{0}");
+                    _rawUrl = _rawUrl.Replace(RevisionPlaceHolder, "{0}");
                     isMatch = true;
                 }
             }

--- a/src/GitLink/Providers/UncProvider.cs
+++ b/src/GitLink/Providers/UncProvider.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitTools.Git;
+using System.Text.RegularExpressions;
+
+namespace GitLink.Providers
+{
+    /// <summary>
+    /// A git provider for UNC network paths.
+    /// </summary>
+    public class UncProvider : ProviderBase, IBackSlashSupport
+    {
+        /// <summary>
+        /// A class with placeholder constants.
+        /// </summary>
+        public static class PlaceHolder
+        {
+            /// <summary>
+            /// Gets a placeholder for file name.
+            /// </summary>
+            public const string FileName = "{filename}";
+
+            /// <summary>
+            /// Gets a placeholder for commit hash.
+            /// </summary>
+            public const string Revision = "{revision}";
+        }
+
+        private static readonly Regex _uncRegex = new Regex(@"^(//|\\).+");
+        private string _rawUrl;
+
+        public UncProvider()
+            : base(new GitPreparer())
+        {
+        }
+
+        public override string RawGitUrl
+        {
+            get { return _rawUrl; }
+        }
+
+        public bool IsBackSlashSupported
+        {
+            get
+            {
+                if (RawGitUrl.StartsWith("//"))
+                    return false;
+                else
+                    return true;
+            }
+        }
+
+        public override bool Initialize(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return false;
+            }
+
+            bool isMatch = false;
+            if(_uncRegex.IsMatch(url))
+            {
+                if (url.Contains(PlaceHolder.FileName))
+                {
+                    _rawUrl = url.Replace(PlaceHolder.FileName, "%var2%");
+                    isMatch = true;
+                }
+
+                if (url.Contains(PlaceHolder.Revision))
+                {
+                    _rawUrl = _rawUrl.Replace(PlaceHolder.Revision, "{0}");
+                    isMatch = true;
+                }
+            }
+
+            return isMatch;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #131 .

### Checklist

- [x] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Added `UncProvider`.
- Added `IBackSlashSupport` and updated `Linker` to look if used implementation of `IProvider` implements this interface. If it does, it is asked whether back slashes are supported.
