### PR TITLE
Improve logging on missing files

### DIFF
--- a/src/GitLink/Extensions/RepositoryExtensions.cs
+++ b/src/GitLink/Extensions/RepositoryExtensions.cs
@@ -39,7 +39,7 @@ namespace GitLink
 
                 if (entry == null)
                 {
-                    Log.Warning("Unable to find file in git.");
+                    Log.Warning($"Unable to find file in git: \"{path}\".");
                     return path;
                 }
 
@@ -51,7 +51,7 @@ namespace GitLink
                 {
                     if (i < relativePathSegments.Length - 1)
                     {
-                        Log.Error("Found a file where we expected to find a directory.");
+                        Log.Error($"Found a file where we expected to find a directory: \"{path}\".");
                         return path;
                     }
                 }


### PR DESCRIPTION
When a file is missing from git, all we get is this warning: `Unable to find file in git.`

With this fix, the actual path to the file is given so that the message is actionable.