### PR TITLE
Exit with 1 on failure

### DIFF
--- a/src/GitLink/Program.cs
+++ b/src/GitLink/Program.cs
@@ -67,7 +67,11 @@ namespace GitLink
                 Method = method,
             };
 
-            Linker.Link(pdbPath, options);
+            if (!Linker.Link(pdbPath, options))
+            {
+                return 1;
+            }
+
             WaitForKeyPressWhenDebugging();
             return 0;
         }


### PR DESCRIPTION
When GitLink fails to modify the PDB it should exit with a failure code.
The behavior of exiting with 0 on success makes it impossible to detect
GitLink breaks in infrastructure.

closes #156
