### PR TITLE
Small change to VisualStudio.com regex

### DIFF
--- a/src/GitLink/Providers/VisualStudioTeamServicesProvider.cs
+++ b/src/GitLink/Providers/VisualStudioTeamServicesProvider.cs
@@ -13,7 +13,7 @@ namespace GitLink.Providers
 
     public class VisualStudioTeamServicesProvider : ProviderBase
     {
-        private static readonly Regex HostingUrlPattern = new Regex(@"(?<url>(?<companyurl>(?:https://)?(?<accountname>([a-zA-Z0-9\-\.]*)?)\.visualstudio\.com/)(?<project>[a-zA-Z0-9\-\.]*)/?_git/(?<repo>[^/]+))");
+        private static readonly Regex HostingUrlPattern = new Regex(@"(?<url>(?<companyurl>(?:https://)?(?<accountname>([a-zA-Z0-9\-\.]*)?)\.visualstudio\.com/)(?<project>[a-zA-Z0-9\-\.]*)/?_git//?(?<repo>[^/]+))");
 
         public VisualStudioTeamServicesProvider()
             : base(new GitPreparer())


### PR DESCRIPTION
Some build systems add an extra slash in the path. Modified the VSTS regex to account for that

Fixes #96 

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file (way to small of a change to add me, imo)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Some systems add an extra slash when referring to visualstudio.com. The regex was modified to account for that (added an optional slash)