### PR TITLE
Couple of bug fixes

### DIFF
--- a/src/GitLink.NuGet/GitLink.NuGet.nuproj
+++ b/src/GitLink.NuGet/GitLink.NuGet.nuproj
@@ -14,7 +14,9 @@
     <ProjectGuid>29e78909-b7fb-472c-a9a0-1749a8be9a9a</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
-    <NuProjPath>$(UserProfile)\.nuget\packages\NuProj\0.11.14-beta\tools</NuProjPath>
+    <_NuGetRoot>$(UserProfile)\.nuget\packages</_NuGetRoot>
+    <_NuGetRoot Condition="'$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</_NuGetRoot>
+    <NuProjPath>$(_NuGetRoot)\NuProj\0.11.14-beta\tools</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">

--- a/src/GitLink/Extensions/RepositoryExtensions.cs
+++ b/src/GitLink/Extensions/RepositoryExtensions.cs
@@ -74,7 +74,7 @@ namespace GitLink
 
             Uri baseUri = new Uri(relativeTo, UriKind.Absolute);
             Uri targetUri = new Uri(target, UriKind.Absolute);
-            return baseUri.MakeRelativeUri(targetUri).ToString();
+            return Uri.UnescapeDataString(baseUri.MakeRelativeUri(targetUri).ToString());
         }
     }
 }


### PR DESCRIPTION
Changes:

- Respect `%NUGET_PACKAGES%` in build files
- Handle backticks in file names

For the latter I looked into adding a test case. The cases around `GetRelativePath` though seem to rely on files checked into the repo. Thought about adding a dummy test file, `Example`1.cs`. But didn't see any good place to put such a file. Happy to work through adding a test here if desired but would need guidance on where to check in some test only source files. 