### PR TITLE
Add IndexAllDepotFiles option (-a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ There are many more parameters you can use. Display the usage doc with the follo
 
 ### Native PDBs
 
-Native PDBs (from C++ projects) are supported by using -a option. All .cpp/.c/.h files from your git depot will be indexed in the PDB.
+Native PDBs (from C++ projects) are supported by using -a option:
+
+    GitLink.exe <nativePdbfile> -a
+
+All source code files from your git depot will be indexed in the PDB.
 
 # How does it work
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ There are many more parameters you can use. Display the usage doc with the follo
 
     GitLink.exe -h
 
+### Native PDBs
+
+Native PDBs (from C++ projects) are supported by using -a option. All .cpp/.c/.h files from your git depot will be indexed in the PDB.
+
 # How does it work
 
 The SrcSrv tool (Srcsrv.dll) enables a client to retrieve the exact version of the source files that were used to build an application. Because the source code for a module can change between versions and over the course of years, it is important to look at the source code as it existed when the version of the module in question was built.

--- a/src/GitLink.sln.DotSettings
+++ b/src/GitLink.sln.DotSettings
@@ -28,6 +28,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/TagAlwaysOnNewLine/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/WrapBeforeAttr/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/WrapLongLines/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/WRAP_LINES/@EntryValue">False</s:Boolean>
 	
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/MaxSingleLineTagLength/@EntryValue">20</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/WrapBeforeAttr/@EntryValue">False</s:Boolean>
@@ -35,6 +36,7 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/MaxBlankLines/@EntryValue">1</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/ProcessingInstructionAttributesFormat/@EntryValue">OnSingleLine</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/TagAttributesFormat/@EntryValue">FirstAttributeOnSingleLine</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
   &lt;TypePattern Priority="100" DisplayName="Type Pattern"&gt;&#xD;
@@ -416,6 +418,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/UserInterface/ShortcutSchemeName/@EntryValue">None</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>

--- a/src/GitLink/LinkOptions.cs
+++ b/src/GitLink/LinkOptions.cs
@@ -23,5 +23,7 @@ namespace GitLink
         public string CommitId { get; set; }
 
         public string GitWorkingDirectory { get; set; }
+
+        public bool IndexAllDepotFiles { get; set; }
     }
 }

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -207,7 +207,13 @@ namespace GitLink
                               where string.Equals(ext, ".cs", StringComparison.OrdinalIgnoreCase)
                                  || string.Equals(ext, ".cpp", StringComparison.OrdinalIgnoreCase)
                                  || string.Equals(ext, ".c", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".cc", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".cxx", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".c++", StringComparison.OrdinalIgnoreCase)
                                  || string.Equals(ext, ".h", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".hh", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".inl", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".hpp", StringComparison.OrdinalIgnoreCase)
                               select file;
             }
 

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -37,30 +37,50 @@ namespace GitLink
 
             var projectSrcSrvFile = pdbPath + ".srcsrv";
             string repositoryDirectory;
-            IReadOnlyCollection<string> sourceFiles;
+            IEnumerable<string> sourceFiles;
             IReadOnlyDictionary<string, string> repoSourceFiles;
+
             using (var pdb = new PdbFile(pdbPath))
             {
-                sourceFiles = pdb.GetFilesAndChecksums().Keys.ToList();
-
-                if (options.GitWorkingDirectory != null)
+                if (options.IndexAllDepotFiles)
                 {
-                    repositoryDirectory = Path.Combine(options.GitWorkingDirectory, ".git");
+                    repositoryDirectory = GitDirFinder.TreeWalkForGitDir(Path.GetDirectoryName(pdbPath));
+                    sourceFiles = GetSourceFilesFromDepot(repositoryDirectory);
                 }
                 else
                 {
-                    string someSourceFile = sourceFiles.FirstOrDefault();
-                    if (someSourceFile == null)
-                    {
-                        Log.Error("No source files were found in the PDB.");
-                        return false;
-                    }
+                    sourceFiles = pdb.GetFilesAndChecksums().Keys.ToList();
 
-                    repositoryDirectory = GitDirFinder.TreeWalkForGitDir(Path.GetDirectoryName(someSourceFile));
-                    if (repositoryDirectory == null)
+                    if (options.GitWorkingDirectory != null)
                     {
-                        Log.Error("No source files found that are tracked in a git repo.");
-                        return false;
+                        repositoryDirectory = Path.Combine(options.GitWorkingDirectory, ".git");
+                    }
+                    else
+                    {
+                        string someSourceFile = sourceFiles.FirstOrDefault();
+                        if (someSourceFile == null)
+                        {
+                            Log.Error("No source files were found in the PDB.");
+                            return false;
+                        }
+
+                        repositoryDirectory = GitDirFinder.TreeWalkForGitDir(Path.GetDirectoryName(someSourceFile));
+                        if (repositoryDirectory == null)
+                        {
+                            Log.Error("No source files found that are tracked in a git repo.");
+                            return false;
+                        }
+
+                        if (!options.SkipVerify)
+                        {
+                            Log.Debug("Verifying pdb file");
+
+                            var missingFiles = pdb.FindMissingOrChangedSourceFiles();
+                            foreach (var missingFile in missingFiles)
+                            {
+                                Log.Warning($"File \"{missingFile}\" missing or changed since the PDB was compiled.");
+                            }
+                        }
                     }
                 }
 
@@ -107,17 +127,6 @@ namespace GitLink
                         // Normalize using file system since we can't find the git repo.
                         Log.Warning($"Unable to find git repo at \"{options.GitWorkingDirectory}\". Using file system to find canonical capitalization of file paths.");
                         repoSourceFiles = sourceFiles.ToDictionary(e => e, e => GetNormalizedPath(e, workingDirectory));
-                    }
-
-                    if (!options.SkipVerify)
-                    {
-                        Log.Debug("Verifying pdb file");
-
-                        var missingFiles = pdb.FindMissingOrChangedSourceFiles();
-                        foreach (var missingFile in missingFiles)
-                        {
-                            Log.Warning($"File \"{missingFile}\" missing or changed since the PDB was compiled.");
-                        }
                     }
 
                     string rawUrl = provider.RawGitUrl;
@@ -182,9 +191,27 @@ namespace GitLink
             Log.Debug("Created source server link file, updating pdb file \"{0}\"", Catel.IO.Path.GetRelativePath(pdbPath, repositoryDirectory));
             PdbStrHelper.Execute(PdbStrExePath, pdbPath, projectSrcSrvFile);
             var indexedFilesCount = repoSourceFiles.Values.Count(v => v != null);
-            Log.Info($"Remote git source information for {indexedFilesCount}/{sourceFiles.Count} files written to pdb: \"{pdbPath}\"");
+            Log.Info($"Remote git source information for {indexedFilesCount}/{sourceFiles.Count()} files written to pdb: \"{pdbPath}\"");
 
             return true;
+        }
+
+        private static IEnumerable<string> GetSourceFilesFromDepot(string repositoryDirectory)
+        {
+            IEnumerable<string> sourceFiles;
+            var repo = new Repository(repositoryDirectory);
+            {
+                sourceFiles = from file in Directory.GetFiles(repo.Info.WorkingDirectory, "*.*", SearchOption.AllDirectories)
+                              where !repo.Ignore.IsPathIgnored(file)
+                              let ext = Path.GetExtension(file)
+                              where string.Equals(ext, ".cs", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".cpp", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".c", StringComparison.OrdinalIgnoreCase)
+                                 || string.Equals(ext, ".h", StringComparison.OrdinalIgnoreCase)
+                              select file;
+            }
+
+            return sourceFiles;
         }
 
         private static void CreateSrcSrv(string srcsrvFile, SrcSrvContext srcSrvContext)

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -60,7 +60,7 @@ namespace GitLink
                         string someSourceFile = sourceFiles.FirstOrDefault();
                         if (someSourceFile == null)
                         {
-                            Log.Error("No source files were found in the PDB.");
+                            Log.Error("No source files were found in the PDB. If you're PDB is a native one you should use -a option.");
                             return false;
                         }
 

--- a/src/GitLink/Program.cs
+++ b/src/GitLink/Program.cs
@@ -31,6 +31,7 @@ namespace GitLink
             string baseDir = null;
             string pdbPath = null;
             bool skipVerify = false;
+            bool allDepotFiles = false;
             LinkMethod method = LinkMethod.Http;
             var arguments = ArgumentSyntax.Parse(args, syntax =>
             {
@@ -39,6 +40,7 @@ namespace GitLink
                 syntax.DefineOption("commit", ref commitId, "The git ref to assume all the source code belongs to.");
                 syntax.DefineOption("baseDir", ref baseDir, "The path to the root of the git repo.");
                 syntax.DefineOption("s|skipVerify", ref skipVerify, "Verify all source files are available in source control.");
+                syntax.DefineOption("a|allDepotFiles", ref allDepotFiles, "Index all source files from depot. Add this option for native PDBs (C++).");
                 syntax.DefineParameter("pdb", ref pdbPath, "The PDB to add source indexing to.");
 
                 if (!string.IsNullOrEmpty(pdbPath) && !File.Exists(pdbPath))
@@ -65,6 +67,7 @@ namespace GitLink
                 CommitId = commitId,
                 SkipVerify = skipVerify,
                 Method = method,
+                IndexAllDepotFiles = allDepotFiles,
             };
 
             if (!Linker.Link(pdbPath, options))

--- a/src/GitLinkTask/GitLink.targets
+++ b/src/GitLinkTask/GitLink.targets
@@ -10,6 +10,7 @@
         PdbFile="$(IntermediateOutputPath)$(TargetName).pdb"
         Method="$(GitLinkMethod)"
         SkipVerify="$(GitLinkSkipVerify)"
+        IndexAllDepotFiles="$(GitLinkIndexAllDepotFiles)"              
         GitRemoteUrl="$(GitLinkGitRemoteUrl)"
         GitWorkingDirectory="$(GitWorkingDirectory)"
         GitCommitId="$(GitCommitId)"

--- a/src/GitLinkTask/LinkPdbToGitRemote.cs
+++ b/src/GitLinkTask/LinkPdbToGitRemote.cs
@@ -21,6 +21,8 @@ namespace GitLinkTask
 
         public bool SkipVerify { get; set; }
 
+        public bool IndexAllDepotFiles { get; set; }
+
         public string GitRemoteUrl { get; set; }
 
         public string GitCommitId { get; set; }
@@ -40,6 +42,7 @@ namespace GitLinkTask
                 GitRemoteUrl = GitRemoteUrl != null ? new Uri(GitRemoteUrl, UriKind.Absolute) : null,
                 CommitId = GitCommitId,
                 GitWorkingDirectory = GitWorkingDirectory,
+                IndexAllDepotFiles = IndexAllDepotFiles,
             };
             bool success = Linker.Link(PdbFile.GetMetadata("FullPath"), options);
 


### PR DESCRIPTION
It allows to properly index sources for native Pdbs

A few remarks:
- I guess we should detect native pdbs and use that option automatically. I didn"t find any relevant flags in the Pdb current structure)
- Source files extensions list is hardcoded. Maybe we should allow a regex as input.

On a simple cpp project, source information looks like this:
```
VERSION=2
SRCSRV: variables ------------------------------------------
RAWURL=https://raw.github.com/jairbubbles/BitmapFont/bfaf267c467dc18be3b037d80d45bcec7eb51cff/%var2%
SRCSRVVERCTRL=https
SRCSRVTRG=%RAWURL%
SRCSRV: source files ---------------------------------------
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\BitmapFont.cpp*BitmapFont/BitmapFont.cpp
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\BitmapFontCache.cpp*BitmapFont/BitmapFontCache.cpp
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\BitmapFontCache.h*BitmapFont/BitmapFontCache.h
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\BitmapFontCache_Test.cpp*BitmapFont/BitmapFontCache_Test.cpp
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\Rect.h*BitmapFont/Rect.h
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\Rect_Test.cpp*BitmapFont/Rect_Test.cpp
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\stdafx.cpp*BitmapFont/stdafx.cpp
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\stdafx.h*BitmapFont/stdafx.h
C:\Users\jairb\Source\Repos\BitmapFont\BitmapFont\targetver.h*BitmapFont/targetver.h
SRCSRV: end ------------------------------------------------
```

Which seems ok. (I didn't test in Visual Studio if symbols are correctly retrieved yet).

Fixes #166 