### PR TITLE
Properly detect when .pdb file use the new Portable PDB format

### DIFF
--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Pdb\PdbStream.cs" />
     <Compile Include="Pdb\SrcSrv.cs" />
     <Compile Include="Pdb\SrcSrvContext.cs" />
+    <Compile Include="Helpers\PortablePdbHelper.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\BitBucketProvider.cs" />

--- a/src/GitLink/Helpers/PortablePdbHelper.cs
+++ b/src/GitLink/Helpers/PortablePdbHelper.cs
@@ -1,0 +1,55 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PortablePdbHelper.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2016 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace GitLink
+{
+    using System.IO;
+
+    internal static class PortablePdbHelper
+    {
+        /// <summary>
+        /// Is the given .pdb using the new Portable format ? (https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md)
+        /// </summary>
+        /// <param name="pdbPath">.pdb file path</param>
+        /// <returns>Returns if it's a Portable PDB</returns>
+        public static bool IsPortablePdb(string pdbPath)
+        {
+            using (var fs = File.Open(pdbPath, FileMode.Open, FileAccess.Read))
+            using (var br = new BinaryReader(fs))
+            {
+                // More infos in chapter II.24.2 of ECMA-335 (http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf)
+                var signature = 0x424A5342;
+                if (br.ReadUInt32() != signature)
+                {
+                    return false;
+                }
+
+                var majorVersion = br.ReadUInt16();
+                if (majorVersion != 1)
+                {
+                    return false;
+                }
+
+                var minorVersion = br.ReadUInt16();
+                if (minorVersion != 1)
+                {
+                    return false;
+                }
+
+                var reserved = br.ReadUInt32();
+                if (reserved != 0)
+                {
+                    return false;
+                }
+
+                var versionLength = br.ReadUInt32();
+                var version = System.Text.Encoding.UTF8.GetString(br.ReadBytes((int)versionLength));
+
+                return version.StartsWith("PDB v1.0");
+            }
+        }
+    }
+}

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -50,6 +50,12 @@ namespace GitLink
                 }
             }
 
+            if (PortablePdbHelper.IsPortablePdb(pdbPath))
+            {
+                Log.Warning("Portable PDB format is not compatible with GitLink. Please use SourceLink (https://github.com/ctaggart/SourceLink).");
+                return true;
+            }
+
             if (options.IndexAllDepotFiles)
             {
                 if (repositoryDirectory == null)


### PR DESCRIPTION
Rather than throwing an exception we log a warning asking the user to use SourceLink:

![image](https://user-images.githubusercontent.com/15875066/30252018-55b5820a-966b-11e7-8c73-4a5f2abfb5ae.png)

The process still returns 0 in that case and will not break builds when  people switch to new format.

If we do want to return an error, we should have specific error codes for each error cases.