### PR TITLE
Prefer origin remote over others

### DIFF
--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -7,11 +7,13 @@
     <ApplicationIcon>Logo.ico</ApplicationIcon>
     <IsPackable>false</IsPackable>
     <PackageId>GitLink_Inner</PackageId>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0009" />
     <PackageReference Include="ImpromptuInterface" Version="6.2.2" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e161008-1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="pdbstr.exe">

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -110,8 +110,9 @@ namespace GitLink
                     var candidateProviders = from remote in repository.Value.Network.Remotes
                                              let p = providerManager.GetProvider(remote.Url)
                                              where p != null
-                                             select p;
-                    provider = candidateProviders.FirstOrDefault();
+                                             select (remote.Name, Provider: p);
+                    provider = candidateProviders.FirstOrDefault(c => c.Name == "origin").Provider
+                        ?? candidateProviders.FirstOrDefault().Provider;
                 }
                 else
                 {


### PR DESCRIPTION
When there are multiple remotes, if any are named "origin" use that one for the default source URL instead of the remote that comes first in alphabetical order.
This helps prevent accidentally referencing forks of a project in the PDB