### PR TITLE
Suppress warning for source files that fall under intermediate output path

### DIFF
--- a/src/GitLink/LinkOptions.cs
+++ b/src/GitLink/LinkOptions.cs
@@ -25,5 +25,7 @@ namespace GitLink
         public string GitWorkingDirectory { get; set; }
 
         public bool IndexAllDepotFiles { get; set; }
+
+        public string IntermediateOutputPath { get; set; }
     }
 }

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -127,7 +127,9 @@ namespace GitLink
                 try
                 {
                     Repository repo = repository.Value;
-                    repoSourceFiles = sourceFiles.ToDictionary(e => e, e => repo.GetNormalizedPath(e));
+                    repoSourceFiles = sourceFiles
+                        .Where(f => !f.StartsWithIgnoreCase(options.IntermediateOutputPath))
+                        .ToDictionary(e => e, e => repo.GetNormalizedPath(e));
                 }
                 catch (RepositoryNotFoundException)
                 {

--- a/src/GitLinkTask/LinkPdbToGitRemote.cs
+++ b/src/GitLinkTask/LinkPdbToGitRemote.cs
@@ -5,6 +5,7 @@
 namespace GitLinkTask
 {
     using System;
+    using System.IO;
     using Catel.Logging;
     using global::GitLink;
     using Microsoft.Build.Framework;
@@ -31,6 +32,8 @@ namespace GitLinkTask
 
         public string GitWorkingDirectory { get; set; }
 
+        public string IntermediateOutputPath { get; set; }
+
         private LinkMethod MethodEnum { get; set; }
 
         public override bool Execute()
@@ -45,10 +48,18 @@ namespace GitLinkTask
                 CommitId = GitCommitId,
                 GitWorkingDirectory = GitWorkingDirectory,
                 IndexAllDepotFiles = IndexAllDepotFiles,
+                IntermediateOutputPath = Path.GetFullPath(AddTrailingSlash(IntermediateOutputPath)),
             };
             bool success = Linker.Link(PdbFile.GetMetadata("FullPath"), options);
 
             return success && !Log.HasLoggedErrors;
+        }
+
+        private static string AddTrailingSlash(string path)
+        {
+            return path.EndsWith(Path.DirectorySeparatorChar.ToString())
+                ? path
+                : path + Path.DirectorySeparatorChar;
         }
 
         private class MSBuildListener : LogListenerBase

--- a/src/GitLinkTask/build/GitLink.targets
+++ b/src/GitLinkTask/build/GitLink.targets
@@ -17,6 +17,7 @@
         GitRemoteUrl="$(GitLinkGitRemoteUrl)"
         GitWorkingDirectory="$(GitWorkingDirectory)"
         GitCommitId="$(GitCommitId)"
+        IntermediateOutputPath="$(IntermediateOutputPath)"
         ContinueOnError="$(GitLinkContinueOnError)" />
   </Target>
 </Project>


### PR DESCRIPTION
GitLink warns when source files aren't discoverable in the git repo since source server support will fail when debugging into that source file. But when these source files are generated by the build, the warnings are not actionable and the developer should already know these won't be available to debug into. The eventual fix for this is SourceLink which can embed such source files into the PDB. So for now, this PR just suppresses the useless and noisy warnings.