### PR TITLE
#155 Resolves repository location based on pdb path

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,4 @@ Geert van Horrik <geert@catenalogic.com>
 Wesley Eledui <wefilmer@gmail.com>
 Marek Fišera <mara@neptuo.com>
 Shai Nahum <ShayHello1995@gmail.com>
+Amadeusz Wieczorek <mail@amadeusw.com>

--- a/README.md
+++ b/README.md
@@ -72,11 +72,9 @@ When working with a repository using uncommon URL you can use placeholders to sp
 
 The custom url will be used to fill the placeholders with the relative file path and the revision hash.
 
-### More options
+### Git repository location
 
-There are many more parameters you can use. Display the usage doc with the following command line:
-
-    GitLink.exe -h
+GitLink resolves the git repository based on the location of the pdb file. If the pdb file is located outside of the git repository, use the `-baseDir` parameter to point to the top-level directory of the repository.
 
 ### Native PDBs
 
@@ -85,6 +83,12 @@ Native PDBs (from C++ projects) are supported by using -a option:
     GitLink.exe <nativePdbfile> -a
 
 All known C++ source files from your git depot will be indexed in the PDB.
+
+### More options
+
+There are many more parameters you can use. Display the usage doc with the following command line:
+
+    GitLink.exe -h
 
 # How does it work
 


### PR DESCRIPTION
Fixes #155 

### Changes proposed in this pull request:

* Finds the repo root based on the pdb path. Previously, repo root was resolved based on an arbitrary file, which might have been located outside of the repo, e.g. in the global .nuget cache directory
* Consolidates code such that there is only one way to resolve repo root and the error message is descriptive and helpful
* In Readme, explains how repo root is located and explains the `-baseDir` parameter
* Also improves the error messages when libgit2sharp fails to initialize. 

### Checklist

- [X] I have included examples or tests (improved readme)
- [ ] I have updated the change log (where is it?)
- [X] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)
