### PR TITLE
Fix crash when running GitLink directly from command line

### DIFF
--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -116,7 +116,7 @@ namespace GitLink
                 try
                 {
                     Repository repo = repository.Value;
-                    
+
                     var files = string.IsNullOrEmpty(options.IntermediateOutputPath) ?
                                 sourceFiles : sourceFiles.Where(f => !f.StartsWithIgnoreCase(options.IntermediateOutputPath));
 

--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -116,9 +116,11 @@ namespace GitLink
                 try
                 {
                     Repository repo = repository.Value;
-                    repoSourceFiles = sourceFiles
-                        .Where(f => !f.StartsWithIgnoreCase(options.IntermediateOutputPath))
-                        .ToDictionary(e => e, e => repo.GetNormalizedPath(e));
+                    
+                    var files = string.IsNullOrEmpty(options.IntermediateOutputPath) ?
+                                sourceFiles : sourceFiles.Where(f => !f.StartsWithIgnoreCase(options.IntermediateOutputPath));
+
+                    repoSourceFiles = files.ToDictionary(e => e, e => repo.GetNormalizedPath(e));
                 }
                 catch (RepositoryNotFoundException)
                 {


### PR DESCRIPTION
When not using a MSBuild task `options.IntermediateOutputPath` was null and was leading to a null reference exception.