### PR TITLE
Add LinkDirectory for directory path

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,3 +16,4 @@ Wesley Eledui <wefilmer@gmail.com>
 Marek Fišera <mara@neptuo.com>
 Shai Nahum <ShayHello1995@gmail.com>
 Amadeusz Wieczorek <mail@amadeusw.com>
+Adrien JUND <liryna.stark@gmail.com>


### PR DESCRIPTION
Call LinkDirectory when pdbPath is a directory
Cache sourceFilesList for option -a

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
See https://github.com/GitTools/GitLink/issues/191