### PR TITLE
Display pdbPath in case of no source files found error.

### DIFF
--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -84,7 +84,7 @@ namespace GitLink
                 _sourceFilesList = GetSourceFilesFromPdb(pdbPath, !options.SkipVerify);
                 if (!_sourceFilesList.Any())
                 {
-                    Log.Error("No source files were found in the PDB. If you're PDB is a native one you should use -a option.");
+                    Log.Error($"No source files were found in the PDB: {pdbPath}. If you're PDB is a native one you should use -a option.");
                     return false;
                 }
             }


### PR DESCRIPTION
### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-Display pdbPath in case of no source files found error. This will help to know which pdb stop the analyze of a full folder of pdb.

