### PR TITLE
Fix Powershell download on TLS > 1.0 only servers.

### DIFF
--- a/src/GitLink/Pdb/SrcSrv.cs
+++ b/src/GitLink/Pdb/SrcSrv.cs
@@ -37,7 +37,7 @@ namespace GitLink.Pdb
                     {
                         sw.WriteLine("TRGFILE=%fnbksl%(%targ%%var2%)");
                         sw.WriteLine("SRCSRVTRG=%TRGFILE%");
-                        sw.WriteLine("SRCSRVCMD=powershell invoke-command -scriptblock {$webClient = New-Object System.Net.WebClient; $webClient.UseDefaultCredentials = $true; $webClient.DownloadFile('%RAWURL%', '%TRGFILE%');}");
+                        sw.WriteLine("SRCSRVCMD=powershell invoke-command -scriptblock {[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls11 -bor [System.Net.SecurityProtocolType]::Tls12; $webClient = New-Object System.Net.WebClient; $webClient.UseDefaultCredentials = $true; $webClient.DownloadFile('%RAWURL%', '%TRGFILE%');}");
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #200 

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Set `System.Net.ServicePointManager.SecurityProtocol` to always accept Tls 1.1 and 1.2 in the powershell download script embedded in the PDBs.
