### PR TITLE
Improve empty source file list error message

### DIFF
--- a/src/GitLink/Linker.cs
+++ b/src/GitLink/Linker.cs
@@ -85,7 +85,7 @@ namespace GitLink
 
                 if (!_sourceFilesList.Any())
                 {
-                    Log.Error($"No source files were found in the PDB: {pdbPath}. If you're PDB is a native one you should use -a option.");
+                    Log.Error($"No source files were found in the PDB: {pdbPath}. If your PDB is native you should use the -a option.");
                     return false;
                 }
 


### PR DESCRIPTION
We noticed that the error message provided when there were no source files found could use a little improvement. This makes a minor update to improve the grammar and clarity.