### PR TITLE
Add urlencode filename token

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@
 # Please keep the list sorted.
 
 Andrew Arnott <andrewarnott@gmail.com>
+David Ducatel <david@ducatel.eu>
 Geert van Horrik <geert@catenalogic.com>
 Wesley Eledui <wefilmer@gmail.com>
 Marek Fišera <mara@neptuo.com>

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ When working with a repository using uncommon URL you can use placeholders to sp
 
     GitLink.exe <pdbfile> -u "https://host/projects/catel/repos/catel/browse/{filename}?at={revision}&raw"
 
+Or if you require URL encoded filename you can use `urlencoded_filename` token
+
+    GitLink.exe <pdbfile> -u "http://host/api/v4/projects/42/repository/files/{urlencoded_filename}/raw?ref={revision}"
+
 The custom url will be used to fill the placeholders with the relative file path and the revision hash.
 
 ### Git repository location

--- a/src/GitLink.Tests/Providers/CustomUrlProviderFacts.cs
+++ b/src/GitLink.Tests/Providers/CustomUrlProviderFacts.cs
@@ -25,6 +25,7 @@ namespace GitLink.Tests.Providers
             [TestCase("https://example.com/repo", false)]
             [TestCase("https://bitbucket.intra.company.com/projects/aaa/repos/a/browse/{filename}?raw", true)]
             [TestCase("gopher://example.com/repo", false)]
+            [TestCase("http://gitlab.com/api/v4/projects/42/repository/files/{urlencoded_filename}/raw?ref={revision}&private_token=superToken", true)]
             public void CorrectlyValidatesForUrls(string url, bool expectedValue)
             {
                 var provider = new CustomUrlProvider();
@@ -73,14 +74,16 @@ namespace GitLink.Tests.Providers
                 Assert.IsNull(provider.ProjectUrl);
             }
 
-            [TestCase]
-            public void ReturnsValidRawGitUrl()
+            [TestCase(CorrectUrl)]
+            [TestCase("http://gitlab.com/api/v4/projects/42/repository/files/{urlencoded_filename}/raw?ref={revision}&private_token=superToken")]
+            public void ReturnsValidRawGitUrl(string url)
             {
                 var provider = new CustomUrlProvider();
-                provider.Initialize(CorrectUrl);
+                provider.Initialize(url);
 
-                string correctReturnedUrl = CorrectUrl.Replace("{filename}", "%var2%");
-                correctReturnedUrl = correctReturnedUrl.Replace("{revision}", "{0}");
+                string correctReturnedUrl = url.Replace("{filename}", "%var2%")
+                    .Replace("{revision}", "{0}")
+                    .Replace("{urlencoded_filename}", "%var2%");
 
                 Assert.AreEqual(correctReturnedUrl, provider.RawGitUrl);
             }

--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -26,4 +26,7 @@
   <ItemGroup>
     <Content Include="Logo.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Web" />
+  </ItemGroup>
 </Project>

--- a/src/GitLink/Providers/CustomUrlProvider.cs
+++ b/src/GitLink/Providers/CustomUrlProvider.cs
@@ -12,6 +12,7 @@ namespace GitLink.Providers
     public sealed class CustomUrlProvider : ProviderBase
     {
         private const string FileNamePlaceHolder = "{filename}";
+        private const string UrlEncodedFileNamePlaceHolder = "{urlencoded_filename}";
         private const string RevisionPlaceHolder = "{revision}";
         private static readonly Regex HostingUrlPattern = new Regex(@"https?://.+");
 
@@ -27,14 +28,16 @@ namespace GitLink.Providers
         public override bool Initialize(string url)
         {
             if (string.IsNullOrEmpty(url) || !HostingUrlPattern.IsMatch(url) ||
-               (!url.Contains(FileNamePlaceHolder) && !url.Contains(RevisionPlaceHolder)))
+               (!(url.Contains(FileNamePlaceHolder) || url.Contains(UrlEncodedFileNamePlaceHolder)) &&
+               !url.Contains(RevisionPlaceHolder)))
             {
                 return false;
             }
 
-            if (url.Contains(FileNamePlaceHolder))
+            if (url.Contains(FileNamePlaceHolder) || url.Contains(UrlEncodedFileNamePlaceHolder))
             {
-                _rawUrl = url.Replace(FileNamePlaceHolder, "%var2%");
+                _rawUrl = url.Replace(FileNamePlaceHolder, "%var2%")
+                            .Replace(UrlEncodedFileNamePlaceHolder, "%var2%");
             }
 
             if (url.Contains(RevisionPlaceHolder))


### PR DESCRIPTION
Hi everyone,
I have implemented the feature I have ask in # 211

### Checklist

- [x] I have included examples or tests
- [ ] I have updated the change log --> Where is it ?
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history

### Changes proposed in this pull request:

- Adding `{urlencoded_filename}` token for custom URL provieder
