### PR TITLE
Add CefSharp to the list of projects already using GitLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Below is a list of projects already using GitLink (alphabetically ordered).
 
 - <a href="https://aspnetboilerplate.com" target="_blank">ASP.NET Boilerplate</a>
 - <a href="http://www.catelproject.com" target="_blank">Catel</a>
+- <a href="https://cefsharp.github.io/" target="_blank">CefSharp</a>
 - <a href="http://www.expandframework.com/" target="_blank">eXpand</a>
 - <a href="https://fakeiteasy.github.io/" target="_blank">FakeItEasy</a>
 - <a href="https://github.com/fluentribbon/Fluent.Ribbon" target="_blank">Fluent.Ribbon</a>


### PR DESCRIPTION
### Checklist
N/A (just a README update)

### Changes proposed in this pull request:
CefSharp also uses GitLink, so this PR adds CefSharp to the list of projects already using GitLink.
